### PR TITLE
Fix #161: Apply landscape keyboard height dynamically on orientation …

### DIFF
--- a/src/main/kotlin/tribixbite/cleverkeys/CleverKeysService.kt
+++ b/src/main/kotlin/tribixbite/cleverkeys/CleverKeysService.kt
@@ -370,7 +370,7 @@ class CleverKeysService : InputMethodService(),
                 if (intent?.action == ACTION_THEME_CHANGED) {
                     // 1. Refresh config to pick up new values (colors, etc.)
                     _configManager.refresh(resources)
-                    
+
                     // 2. FORCE view recreation.
                     // Even if the theme ID hasn't changed (e.g. editing custom theme colors),
                     // we need to recreate the view to pick up the new colors.
@@ -564,6 +564,17 @@ class CleverKeysService : InputMethodService(),
     private fun refresh_config() {
         // Delegate to ConfigurationManager, which will trigger listener callbacks
         _configManager.refresh(resources)
+    }
+
+    /**
+    * Recalculate the keyboard height based on current orientation/foldable state
+    * and apply it to the keyboard view. Call this whenever the height might have changed.
+    */
+    private fun refreshKeyboardHeight() {
+        if (!::_neuralLayoutBridge.isInitialized) return
+        val height = _neuralLayoutBridge.calculateDynamicKeyboardHeight()
+        _keyboardView.layoutParams?.height = height.toInt()
+        _keyboardView.requestLayout()
     }
 
     // ConfigChangeListener implementation (v1.32.345)
@@ -774,6 +785,7 @@ class CleverKeysService : InputMethodService(),
         // Without this, landscape margins are never applied because Config.orientation_landscape
         // isn't updated when the device rotates
         refresh_config()
+        refreshKeyboardHeight()
     }
 
     override fun onUpdateSelection(
@@ -871,6 +883,12 @@ class CleverKeysService : InputMethodService(),
         // triggers preference changes before keyboard has been used)
         if (!::_layoutBridge.isInitialized) {
             return
+        }
+
+        if (key in setOf("keyboard_height", "keyboard_height_landscape",
+                     "keyboard_height_unfolded", "keyboard_height_landscape_unfolded")) {
+            refreshKeyboardHeight()
+            // Do NOT return here – let the existing handler also run if needed
         }
 
         // Initialize handler lazily (depends on components that may not exist yet)


### PR DESCRIPTION
## Description

This PR fixes **Issue #161**: the landscape height slider did nothing, while the portrait slider controlled both orientations.

**Root cause**: the keyboard height was calculated once on initial layout and never updated when:
- The user moved the landscape height slider.
- The device rotated between portrait and landscape.

**Solution**:
- Added `refreshKeyboardHeight()` method that recalculates the height using `NeuralLayoutBridge` (which already knows how to pick the correct preference based on orientation and foldable state) and applies it to the keyboard view.
- Called this method in `onConfigurationChanged()` so the height updates immediately when the device rotates.
- Called it in `onSharedPreferenceChanged()` when any height‑related preference (`keyboard_height`, `keyboard_height_landscape`, etc.) changes, so the landscape slider takes effect instantly.

**Impact**: users can now set independent heights for portrait and landscape, and both sliders work correctly. No other behaviour is altered.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🎨 Style/UI change (formatting, visual improvements)
- [ ] ♻️ Code refactoring (no functional changes)
- [ ] ⚡ Performance improvement
- [ ] ✅ Test update/addition
- [ ] 🔧 Build/configuration change

---

## Related Issues

Closes #161
Related to #161

---

## Changes Made

- Added `refreshKeyboardHeight()` method in `CleverKeysService.kt`.
- Called it in `onConfigurationChanged()` after `refresh_config()`.
- Added a check for height‑related preference keys in `onSharedPreferenceChanged()` and called `refreshKeyboardHeight()`.

---

## Testing Performed

### Manual Testing

**Test Device:**
- Device: Samsung Galaxy A31
- Android Version: 12
- CleverKeys Version: latest dev

**Test Scenarios:**
- [x] Set portrait height = 40%, landscape = 60%, open keyboard in portrait → height is 40%.
- [x] Rotate to landscape → height becomes 60%.
- [x] Adjust landscape slider → height updates immediately.
- [x] Rotate back to portrait → height returns to 40%.
- [x] Ensure no other settings are affected (e.g., margins, opacity, layout).

**Results:**
All tests pass. The landscape slider now works exactly as expected, and orientation switching updates the height correctly.

### Automated Testing

```bash
./gradlew test
./gradlew lint