### PR TITLE
Fix the broken star history chart in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,11 +472,11 @@ If you want a lightweight keyboard without gesture typing, we recommend the orig
 
 # ⭐ Star History
 
-<a href="https://star-history.com/#tribixbite/CleverKeys&Date">
+<a href="https://star-history.dera.page/#tribixbite/CleverKeys&Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=tribixbite/CleverKeys&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=tribixbite/CleverKeys&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=tribixbite/CleverKeys&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=tribixbite/CleverKeys&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=tribixbite/CleverKeys&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=tribixbite/CleverKeys&type=Date" />
  </picture>
 </a>
 


### PR DESCRIPTION
The star history chart in the README is currently broken due to GitHub stargazer API restrictions. This change points the chart and its wrapping link at a working mirror that serves the same chart from a different data source and requires no API token, so the chart renders correctly again.