### PR TITLE
feat(pinyin): composing IME — pack schema, CKPY format, tap engine, swipe feed (gh #177)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -591,6 +591,9 @@ tasks.register('runPureTests', JavaExec) {
     // gh #177 (2026-09-11): the composing-IME container format — CKPY v1 byte layout,
     // prefix lookup, and the untrusted-input bounds, all pure JVM (no android.jar).
     'tribixbite.cleverkeys.pinyin.CkpyPhraseTableTest',
+    // gh #177 Phase 1: the composing state machine — normalization, deterministic candidate
+    // assembly (exact → completions → greedy segmentation), buffer edit rules.
+    'tribixbite.cleverkeys.pinyin.PinyinSessionTest',
     'tribixbite.cleverkeys.AutocorrectDefaultsDriftTest',
     'tribixbite.cleverkeys.ShortSwipeIntentTest',
     'tribixbite.cleverkeys.customization.ShortSwipeMappingTest',
@@ -1066,6 +1069,12 @@ tasks.register('runMockTests', JavaExec) {
     'tribixbite.cleverkeys.MarginPercentPolicyTest',
     'tribixbite.cleverkeys.theme.MonetDynamicColorGateTest',
     'tribixbite.cleverkeys.langpack.LanguagePackImportTest',
+    // gh #177 Phase 1: the pinyin IME glue — pack-driven activation, composing region,
+    // committed-text fallback, candidate taps, swipe feeding, password bypass (MockK).
+    'tribixbite.cleverkeys.pinyin.PinyinControllerTest',
+    // gh #177 Phase 2: the swipe pipeline's pinyin seam — a consuming hook suppresses the
+    // English pipeline (incl. the empty-decode guard), a non-consuming one is inert.
+    'tribixbite.cleverkeys.SuggestionPinyinHookTest',
     'tribixbite.cleverkeys.UserDictionaryLocaleFilterTest',
     'tribixbite.cleverkeys.MLDataCollectionToggleTest',
     'tribixbite.cleverkeys.clipboard.ClipboardLockedStartupTest',

--- a/build.gradle
+++ b/build.gradle
@@ -588,6 +588,9 @@ tasks.register('runPureTests', JavaExec) {
     'tribixbite.cleverkeys.BeamSearchModelsTest',
     'tribixbite.cleverkeys.ConfigDefaultsTest',
     'tribixbite.cleverkeys.DictionaryBinFormatTest',
+    // gh #177 (2026-09-11): the composing-IME container format — CKPY v1 byte layout,
+    // prefix lookup, and the untrusted-input bounds, all pure JVM (no android.jar).
+    'tribixbite.cleverkeys.pinyin.CkpyPhraseTableTest',
     'tribixbite.cleverkeys.AutocorrectDefaultsDriftTest',
     'tribixbite.cleverkeys.ShortSwipeIntentTest',
     'tribixbite.cleverkeys.customization.ShortSwipeMappingTest',

--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -74,6 +74,7 @@
 | `context-learning-and-next-word.md` | **NEW 2026-08-06** Persistent context LM, master learning privacy gate, opt-in next-word prediction, suggestion provenance, learned-data manager | ✅ Implemented |
 | `ctc-swipe-engine.md` | **UPDATED 2026-08-15** CTC trie-beam swipe engine — WIRED opt-in `ctc` mode (2026-08-08): CleverKeys-trained ONNX encoder, router/adapter/settings/provenance As-Built | ✅ Implemented |
 | `cursor-aware-predictions.md` | Cursor sync + cursor-park next-word integration | ✅ Implemented |
+| `pinyin-ime.md` | **NEW 2026-09-11** Pinyin composing IME (gh #177): `inputMethod` pack field, `CKPY` phrase table, candidate/commit plan | 📝 Planning (format implemented) |
 | `architectural-decisions.md` | Architectural Decision Records | ✅ Active |
 
 ### `/docs/eval/` Decoder Evaluations (2026-07/08)

--- a/docs/TABLE_OF_CONTENTS.md
+++ b/docs/TABLE_OF_CONTENTS.md
@@ -74,7 +74,7 @@
 | `context-learning-and-next-word.md` | **NEW 2026-08-06** Persistent context LM, master learning privacy gate, opt-in next-word prediction, suggestion provenance, learned-data manager | ✅ Implemented |
 | `ctc-swipe-engine.md` | **UPDATED 2026-08-15** CTC trie-beam swipe engine — WIRED opt-in `ctc` mode (2026-08-08): CleverKeys-trained ONNX encoder, router/adapter/settings/provenance As-Built | ✅ Implemented |
 | `cursor-aware-predictions.md` | Cursor sync + cursor-park next-word integration | ✅ Implemented |
-| `pinyin-ime.md` | **NEW 2026-09-11** Pinyin composing IME (gh #177): `inputMethod` pack field, `CKPY` phrase table, candidate/commit plan | 📝 Planning (format implemented) |
+| `pinyin-ime.md` | **UPDATED 2026-09-11** Pinyin composing IME (gh #177): `inputMethod` pack field, `CKPY` phrase table, composing session + candidates, swipe feed | 🧩 Implemented, device validation pending |
 | `architectural-decisions.md` | Architectural Decision Records | ✅ Active |
 
 ### `/docs/eval/` Decoder Evaluations (2026-07/08)

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -33,7 +33,7 @@ Technical documentation for CleverKeys, an Android keyboard with on-device swipe
 | [Dictionary System](./dictionary-and-language-system.md) | Word lookup, frequency ranking, user dictionary |
 | [Secondary Language](./secondary-language-integration.md) | Multi-language typing, language detection |
 | [Language-Specific Dictionary](./language-specific-dictionary-manager.md) | Per-language dictionary management |
-| [Pinyin IME](./pinyin-ime.md) | Composing pinyin pack schema (gh #177), `CKPY` phrase table, candidate/commit plan |
+| [Pinyin IME](./pinyin-ime.md) | Composing pinyin IME (gh #177): `inputMethod` + `CKPY` pack format, composing session, candidates, swipe feed |
 
 ### Customization
 

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -33,6 +33,7 @@ Technical documentation for CleverKeys, an Android keyboard with on-device swipe
 | [Dictionary System](./dictionary-and-language-system.md) | Word lookup, frequency ranking, user dictionary |
 | [Secondary Language](./secondary-language-integration.md) | Multi-language typing, language detection |
 | [Language-Specific Dictionary](./language-specific-dictionary-manager.md) | Per-language dictionary management |
+| [Pinyin IME](./pinyin-ime.md) | Composing pinyin pack schema (gh #177), `CKPY` phrase table, candidate/commit plan |
 
 ### Customization
 

--- a/docs/specs/pinyin-ime.md
+++ b/docs/specs/pinyin-ime.md
@@ -2,7 +2,8 @@
 
 **Feature Name**: Pinyin composing IME
 **Priority**: P3 (contribution-track; maintainer priority call)
-**Status**: Planning — pack schema and container format implemented (this document)
+**Status**: In progress — Phases 0–2 implemented (container format, tap engine, swipe feed);
+device validation and pack data outstanding
 **Target Version**: TBD
 **Issue**: [tribixbite/CleverKeys#177](https://github.com/tribixbite/CleverKeys/issues/177)
 **Owner**: Macho0x
@@ -219,98 +220,88 @@ python3 scripts/build_langpack.py --lang zh --name "中文（拼音）" \
 `phrases.bin`, a phrase table without the mode, a non-CKPY-v1 table, or a table over the
 64 MiB reader cap.
 
-### As-built test pins (this PR)
+### As-built test pins (Phases 0–2)
 
 | Behavior | Test |
 |---|---|
 | CKPY header bytes, record framing | `src/test/kotlin/tribixbite/cleverkeys/pinyin/CkpyPhraseTableTest.kt` (`headerFieldsPinTheCkpyV1Layout`, `recordFramingPinsLengthPrefixedUtf8AndRankBytes`) |
 | exact + prefix lookup, normalization | same file (`lookupIsExact`, `withPrefixReturnsTheContiguousRunInKeyOrder`, `lookupsRequireANormalizedQuery`) |
 | malformed tables refused | same file (magic/version/truncation/ordering/ranks/trailing/empty) |
-| manifest field, member carry, couplings | `src/test/kotlin/tribixbite/cleverkeys/langpack/LanguagePackImportTest.kt` (pinyin section: 5 tests) |
+| manifest field, member carry, couplings, per-code manifest read | `src/test/kotlin/tribixbite/cleverkeys/langpack/LanguagePackImportTest.kt` (6 tests) |
+| buffer normalization, candidate assembly, segmentation, edit rules | `src/test/kotlin/tribixbite/cleverkeys/pinyin/PinyinSessionTest.kt` (15 tests) |
+| activation, password bypass, missing-table fallback, composing region, committed fallback, candidate taps, swipe feed | `src/test/kotlin/tribixbite/cleverkeys/pinyin/PinyinControllerTest.kt` (10 tests) |
+| the new `IReceiver` hooks are delegated by the bridge | `KeyEventReceiverBridgeDelegationTest` (existing ratchet) |
 
-## Runtime Design (planned — not in this PR)
+## Runtime Design (implemented for Phases 1–2)
 
 ### Architecture
 
 ```
- tap a–z/' ─► KeyEventHandler.key_up ─► PinyinSession
-                                          │  buffer "nihao"
-                                          ├─► CkpyPhraseTable.withPrefix/lookup
-                                          │       → ranked 汉字 candidates
-                                          ▼
-                                     SuggestionBar (reused; already Unicode-capable)
-                                          │ tap / space
-                                          ▼
-                          InputConnection.commitText("你好", 1)
+ tap a–z/' ─► KeyEventHandler.key_up ─► IReceiver hook ─► PinyinController
+                                                              │  PinyinSession buffer "nihao"
+                                                              ├─► CkpyPhraseTable.withPrefix/lookup
+                                                              │       → ranked 汉字 candidates
+                                                              ▼
+                                                         SuggestionBar (reused; Unicode-capable)
+                                                              │ tap / space
+                                                              ▼
+                                            InputConnection.commitText("你好", 1)
 
- swipe ─► SwipeEngineRouter (geometric, or CTC once zh is served)
-              └─ decoded pinyin surface ─► same PinyinSession (preedit only, NO auto-commit)
+ swipe ─► SwipeEngineRouter (geometric today; CTC optional once zh is served)
+               └─ decoded pinyin surface ─► SuggestionHandler pinyin hook
+                                              └─► same session (preedit only, NO auto-commit)
 ```
 
 ### Components
 
-1. **`PinyinSession`** (`src/main/kotlin/tribixbite/cleverkeys/pinyin/`): owns the buffer,
-   the preedit state, and the candidate slate. Pure JVM except its commit calls, so the
-   state machine is unit-testable. API sketch:
+1. **`PinyinSession`** (`src/main/kotlin/tribixbite/cleverkeys/pinyin/PinyinSession.kt`,
+   implemented): pure state machine over a parsed table. Actual API:
+   `appendLetter(ch): Boolean`, `appendSurface(surface): String`, `backspace(): Boolean`,
+   `candidates(limit = 8): List<Candidate>`, `topCandidate()`, `clear()`. Normalizes case,
+   `ü`→`v`, curly apostrophes; caps the buffer at 48 chars.
 
-   ```kotlin
-   class PinyinSession(private val table: CkpyPhraseTable.Table) {
-       fun append(letter: Char)          // a-z, ' (and v for ü)
-       fun backspace(): Boolean          // true when it consumed the key
-       fun feedSwipe(pinyin: String)     // swipe surface; replaces/appends per policy
-       fun candidates(): List<String>    // ranked Hanzi, bounded
-       fun takeTop(): String?
-       fun reset()
-   }
-   ```
+2. **Phrase engine** (implemented in `PinyinSession.candidates`): exact key match first,
+   then completion keys the buffer prefixes, de-duplicated by text; when neither matches,
+   greedy longest-match segmentation joins known syllables (`woaini` → 我+爱+你) with bounded
+   second-candidate variants. The full lattice decoder remains deferred.
 
-2. **Phrase engine**: exact match on the buffer first; otherwise `withPrefix` results
-   flattened in (rank, key) order with text de-duplication. Multi-syllable keys in the
-   table give phrases (`nihao` → 你好); full segmentation is a follow-up.
+3. **Preedit / composing region — Q1 resolved by implementing both paths**:
+   `PinyinController` publishes the run with `InputConnection.setComposingText(preedit, 1)`
+   and commits with `commitText(hanzi, 1)`. If the editor refuses the FIRST
+   `setComposingText` of a field (returns false), the controller flips that field to the
+   committed-text fallback: the same buffer is mirrored as real text and updates use
+   `commitText`/`deleteSurroundingText` — the pattern the English replace path already uses.
+   Both paths are pinned by `PinyinControllerTest`; **device validation on real editors is
+   still required before release** and may flip the default.
 
-3. **Preedit / composing region**: the planned path uses
-   `InputConnection.setComposingText(preedit, 1)` while composing and `commitText(hanzi, 1)`
-   on selection (which implicitly finishes composing). This is net-new for this codebase —
-   production has **zero** composing calls today and
-   `SuggestionTapPartialReplaceTest` pins the English replace path to NOT use them. The
-   pinyin path is feature-gated, so those pins stay green. If device testing finds editors
-   that mishandle composing, the fallback is the existing commit-then-`deleteSurroundingText`
-   pattern behind the same `PinyinSession` API; the spec requires the fallback to be
-   validated on the maintainer's test phones before release.
+4. **Key interception** (implemented):
+   - `KeyEventHandler.key_up` `Kind.Char`/`Kind.String` calls `IReceiver.pinyinHandleText`
+     before `sendText`, so autocap/TSR/context tracking never see composing letters;
+   - `KEYCODE_DEL` calls `pinyinHandleBackspace` (buffer first, editor once empty);
+   - other key events call `pinyinHandleKeyevent` (Enter commits the top candidate and is
+     NOT consumed; Escape cancels);
+   - suggestion taps route through `SuggestionBridge.onSuggestionSelected` →
+     `PinyinController.onCandidateSelected` (only a word the session offered is consumed);
+   - `KeyEventReceiverBridge` gates the text hook on all modal panes (clipboard
+     tag/edit/search, emoji, GIF) so they keep owning the keyboard.
 
-4. **Key interception** (planned, exact sites):
-   - `KeyEventHandler.key_up` `Kind.Char`/`Kind.String` dispatch
-     (`src/main/kotlin/tribixbite/cleverkeys/KeyEventHandler.kt:96-97`) — branch to the
-     session before `sendText` (`:323`) and its `commitText` (`:482`);
-   - backspace `KEYCODE_DEL` branch (`KeyEventHandler.kt:99-135`) — session first;
-   - suggestion tap → `SuggestionHandler.onSuggestionSelected` (`SuggestionHandler.kt:1501`)
-     — unchanged commit site, fed by pinyin candidates;
-   - swipe → `SuggestionHandler.handleSwipePredictionResults`
-     (`SuggestionHandler.kt:748-978`) — suppress the auto-insert at `:857-966` for pinyin
-     and route the decoded surface into the session.
+5. **Suggestion bar**: reused as-is. Pinyin candidates carry
+   `SuggestionOrigin.PINYIN` (`SuggestionMeta`), a marker color, and the
+   `provenance_origin_pinyin` label, so the long-press provenance sheet names the source.
 
-5. **Suggestion bar**: reuse as-is. It renders arbitrary `String`s
-   (`SuggestionBar.createSuggestionView:145`, `setSuggestionsWithScores:552`), already
-   honours password mode (`isPasswordField:924`, `setPasswordMode`), and has a
-   provenance/long-press surface for later.
+6. **Swipe serving**: `SuggestionHandler.handleSwipePredictionResults` calls the
+   `PinyinComposingHook` BEFORE the password/empty guards and before every English step
+   (rescore, possessives, auto-insert), so a pinyin decode buffers the spelling and never
+   auto-commits. Geometric serves pinyin spellings today (QWERTY projection); the optional
+   CTC `zh` row remains deferred until a corpus evaluation exists.
 
-6. **Swipe serving**:
-   - geometric: works today — pinyin letters project onto QWERTY
-     (`GeometricEngineAdapter.dictionaryFor:585` reads the pack's CKDT);
-   - CTC: optional follow-up — add a `zh` row to `CtcLanguageSupport.SUPPORTED`
-     (`swipe/ctc/CtcLanguageSupport.kt:123`) sourced from the pack's pinyin-spelled CKDT;
-     the Latin encoder is layout-agnostic. Given there is **no pinyin swipe corpus**, the
-     row would be PROVISIONAL-tier by the table's own honesty conventions, and the
-     conversion stage hooks at `CtcEngineAdapter.decodeLexicon:1087` /
-     `applyDisplay:943` where accents and contractions already restore display forms.
+7. **Mode selection / language plumbing** (implemented): `PinyinController` evaluates the
+   active primary language per field via `LanguagePackManager.getInstalledPack(code)` +
+   `getPhrasesPath(code)`, re-checks on language change during typing, and stays inactive
+   when the table is missing/corrupt (keys commit Latin). `LanguageDetector` still has no
+   `zh` profile and `PredictionContextTracker` still bails on CJK cursor sync — explicit
+   selection only.
 
-7. **Mode selection / language plumbing**: pinyin mode is chosen by the active primary
-   language's installed pack declaring `inputMethod: "pinyin"`. `PreferenceUIUpdateHandler`
-   already reloads predictors on language change. Note two existing guards: `LanguageDetector`
-   has no `zh` profile (`LanguageDetector.kt:42-199`, `:373-382`) and
-   `PredictionContextTracker` intentionally bails on CJK cursor sync
-   (`PredictionContextTracker.kt:870-876`); auto-detection must never silently switch into
-   pinyin mode — explicit selection only in P1.
 
 ### Privacy and security
 
@@ -326,46 +317,72 @@ python3 scripts/build_langpack.py --lang zh --name "中文（拼音）" \
 
 ## Testing Strategy
 
-- **Pure JVM** (`runPureTests`): `CkpyPhraseTableTest` — layout bytes, lookup, prefix,
-  malformed inputs, bounds. Runs in CI.
-- **Mock tier** (`runMockTests`): the five pinyin import tests in `LanguagePackImportTest` —
-  mode parsing, member carry, the two couplings, unknown modes, rejection cleanup.
+- **Pure JVM** (`runPureTests`): `CkpyPhraseTableTest` (14) — layout bytes, lookup, prefix,
+  malformed inputs, bounds; `PinyinSessionTest` (15) — normalization, candidate assembly,
+  segmentation, edit rules. Run green on 2026-09-11.
+- **Mock tier** (`runMockTests`): `LanguagePackImportTest` (35) — mode parsing, member
+  carry, the two couplings, unknown modes, rejection cleanup, per-code manifest read;
+  `PinyinControllerTest` (10) — activation, password bypass, missing-table fallback,
+  composing region, committed-text fallback, candidate taps, swipe feed. Both green on
+  2026-09-11.
+- **Full pure suite**: 2,400 tests green except a pre-existing timing microbenchmark
+  (`GeoBenchmarkTest`, environment-sensitive), on 2026-09-11.
 - **Python**: `build_phrase_table.py` verifies its own output by re-parsing it before
   writing; `build_langpack.py` refuses the invalid combinations. A generated table is parsed
   by the Kotlin reader during development (cross-tool round-trip exercised 2026-09-11:
   Python writer → Kotlin reader, including `lü`→`lv` and `ni3`→`ni`).
-- **Engine phases** add: `PinyinSessionTest` (pure), commit-path tests alongside the
-  existing `SuggestionTapPartialReplaceTest` shapes, and instrumented pipeline tests for
-  the composing region on real editors.
+- **Still required**: on-device validation (composing-region behavior in real editors,
+  geometric swipe quality, multi-field switching), and instrumented pipeline coverage in
+  the style of `PipelineCharacterizationTest`.
 
 ## Implementation Plan
 
-### Phase 0 — schema + container format (THIS PR)
+### Phase 0 — schema + container format (DONE)
 
 - [x] `docs/specs/pinyin-ime.md` (this document)
 - [x] `inputMethod` manifest field, `phrases.bin` member, validation + storage accessor
 - [x] `CKPY` v1 reader + unit tests; Python writer; `build_langpack.py` integration
 - [x] Index rows in `docs/specs/README.md` / `docs/TABLE_OF_CONTENTS.md`
-- [ ] Maintainer decision on the composing-region approach (open question Q1)
+- [x] Composing-region decision (Q1): implemented BOTH — composing region primary, per-field
+  committed-text fallback when the editor refuses it (see Component 3). Maintainer may flip
+  the default after device validation.
 
-### Phase 1 — tap-first engine
+### Phase 1 — tap-first engine (CODE DONE; device validation + pack data outstanding)
 
-- [ ] `PinyinSession` + candidate assembly, wired to `KeyEventHandler.key_up`
-- [ ] Suggestion bar candidate display; tap/space/enter commit; backspace editing
-- [ ] Password bypass; fallback-to-Latin on missing table
+- [x] `PinyinSession` + candidate assembly, wired to `KeyEventHandler.key_up`
+- [x] Suggestion bar candidate display; tap/space/enter commit; backspace editing
+- [x] Password bypass; fallback-to-Latin on missing table
 - [ ] First real pack built (pinyin wordfreq spellings + open phrase source), device-tested
+  — blocked on Q4 (data source/licence) and on hardware access
 
-### Phase 2 — swipe
+### Phase 2 — swipe (CODE DONE; device validation outstanding)
 
-- [ ] Suppress auto-insert for pinyin; feed decoded surface into the session
+- [x] Suppress auto-insert for pinyin; feed decoded surface into the session
 - [ ] Validate geometric pinyin swipe quality on device
 - [ ] Optional: `zh` row in `CtcLanguageSupport` (PROVISIONAL) once a corpus evaluation exists
 
-### Phase 3 — polish
+### Phase 3 — polish (PARTIAL)
 
-- [ ] `zh-Hans` / `zh-Hant` pack variants (shared pinyin keys; separate phrase tables)
-- [ ] Candidate ranking with context; user-selection learning behind the privacy gates
-- [ ] Segmentation/lattice decoding for unbounded input; settings surface for space behavior
+- [ ] `zh-Hans` / `zh-Hant` pack variants (shared pinyin keys; separate phrase tables) —
+  pack-data work, no code change required
+- [ ] Candidate ranking with context; user-selection learning behind the privacy gates —
+  deliberately deferred: needs a Hanzi context signal that does not exist yet, and a
+  storage/privacy design of its own
+- [x] Greedy longest-match segmentation for unbounded input
+- [ ] Full lattice decoding; settings surface for space behavior — deferred to their own
+  change (a new Config key + settings UI + backup registry + drift-test updates)
+
+## Deferred (explicitly not in this change)
+
+| Item | Why |
+|---|---|
+| Device testing of the composing region / swipe quality | requires the maintainer's test phones |
+| Distributable `zh-Hans` / `zh-Hant` packs | data source/licence decision (Q4) |
+| Context-aware candidate ranking, selection learning | needs Hanzi context + privacy/storage design |
+| Space-behavior setting | fixed to Chinese convention (commit, no trailing space) for now |
+| CTC `zh` row | no pinyin swipe corpus to justify the PROVISIONAL tier |
+| Lattice segmentation | greedy longest-match ships first; lattice is an accuracy upgrade |
+
 
 ## Dependencies
 
@@ -389,23 +406,24 @@ python3 scripts/build_langpack.py --lang zh --name "中文（拼音）" \
 |---|---|
 | Missing/invalid `phrases.bin` on import | `ImportResult.Error` with a specific message; nothing installed |
 | Unknown `inputMethod` | refused at import with the value named |
-| Corrupt table at runtime | pinyin mode degrades to committing the raw Latin buffer; pack reported broken |
+| Corrupt/unreadable table at runtime | `PinyinController` stays inactive; keys commit raw Latin; no user-facing report yet (settings surface deferred) |
 | Table absent but pack selected | same degradation; English/normal behavior remains available |
 | Password/PIN field | session disabled before any buffer exists |
 
 ## Open Questions
 
-1. **Composing region vs commit-and-replace**: use `setComposingText` (standard, better
-   editor UX, net-new in this codebase) or the repo's existing replace pattern? Recommend
-   composing, with a device-validation gate and the replace path as fallback. Needs the
-   maintainer's call before Phase 1.
-2. **Space behavior**: commit top candidate only, or commit top + trailing space (English
-   auto-space)? Chinese input convention is commit-without-space.
+1. ~~**Composing region vs commit-and-replace**~~ — RESOLVED 2026-09-11 by implementing
+   both: composing region primary, per-field committed-text fallback when the editor
+   refuses `setComposingText`. The maintainer's device validation decides whether the
+   default changes.
+2. **Space behavior**: fixed to commit-top-without-trailing-space (Chinese convention,
+   Q2). A user-facing setting remains future work.
 3. **Pack code shape**: `zh` + name variants vs `zh-hans`/`zh-hant`; the import regex
    accepts both (`^[a-z]{2,3}(?:[_-][a-z0-9]{1,16}){0,4}$`), but settings/SubtypeManager
-   display has no `zh` row yet.
+   display has no `zh` row yet. Not decided by this change (pack naming is data-side).
 4. **Phrase data source/licence** for a distributable pack (e.g. Rime/librime dictionaries,
    CC-CEDICT-derived pinyin data) — pack publication is a separate decision from the format.
+   OPEN — blocks the first real pack.
 
 ## Future Enhancements
 
@@ -417,6 +435,10 @@ python3 scripts/build_langpack.py --lang zh --name "中文（拼音）" \
 
 - Issue: tribixbite/CleverKeys#177
 - `src/main/kotlin/tribixbite/cleverkeys/pinyin/CkpyPhraseTable.kt` — reader, layout KDoc
+- `src/main/kotlin/tribixbite/cleverkeys/pinyin/PinyinSession.kt` — pure composing state machine
+- `src/main/kotlin/tribixbite/cleverkeys/pinyin/PinyinController.kt` — IME glue (activation,
+  composing region + fallback, candidates, commit)
+- `src/main/kotlin/tribixbite/cleverkeys/pinyin/PinyinComposingHook.kt` — swipe seam
 - `src/main/kotlin/tribixbite/cleverkeys/langpack/LanguagePackManager.kt` — manifest + import
 - `scripts/build_phrase_table.py`, `scripts/build_langpack.py` — writers
 - `docs/specs/ctc-architecture-and-multiscript-guide.md`,

--- a/docs/specs/pinyin-ime.md
+++ b/docs/specs/pinyin-ime.md
@@ -1,0 +1,430 @@
+# Pinyin IME (zh-Hans / zh-Hant) — Feature Specification
+
+**Feature Name**: Pinyin composing IME
+**Priority**: P3 (contribution-track; maintainer priority call)
+**Status**: Planning — pack schema and container format implemented (this document)
+**Target Version**: TBD
+**Issue**: [tribixbite/CleverKeys#177](https://github.com/tribixbite/CleverKeys/issues/177)
+**Owner**: Macho0x
+**Reviewers**: maintainer
+
+## Feature Overview
+
+### Summary
+
+Add a **Pinyin composing IME** for Simplified (`zh-Hans`) and Traditional (`zh-Hant`)
+Chinese: the user types or swipes toneless pinyin on the existing QWERTY letters, the
+keyboard shows a pinyin preedit, the suggestion bar shows ranked 汉字/漢字 candidates, and
+tapping a candidate (or space) commits it. Committed text is Hanzi; keys stay Latin; no
+JNI, no new ONNX model, no network.
+
+### Motivation
+
+CleverKeys language packs assume **committed text = the letters on the keys**. A `zh`
+wordfreq dump of `你/好` cannot be swiped on QWERTY, and a prefix dictionary over Hanzi
+cannot be typed. Chinese needs two things the current formats do not model:
+
+1. a way to declare that a pack's content is *not* a wordfreq lexicon
+   ("compose Latin keys into other text"), and
+2. a **1:N pinyin key → ranked candidate text** table — `CKDT` stores exactly one display
+   word per lookup key, so it cannot express `nihao → 你好, 妳好, …`.
+
+There is no FOSS daily-driver path for Pinyin swipe on this keyboard today. This spec pins
+the pack-level contract and the container format first, so the engine work (taps, swipe,
+composing region) lands against a fixed schema instead of inventing one mid-implementation.
+
+### Goals
+
+- A sideloaded `langpack-zh-Hans.zip` / `langpack-zh-Hant.zip` (SAF, same flow as every
+  other pack) that declares `"inputMethod": "pinyin"` and carries a `phrases.bin`.
+- On-device lookup only: pinyin key → ranked Hanzi candidates, prefix-queryable.
+- Reuse of the shipped swipe engines: geometric already decodes Latin surfaces on QWERTY;
+  CTC decodes the same once `zh` has a lexicon. Neither needs retraining.
+- Password/PIN fields never compose, never convert, never learn.
+- English lexicon isolation while Chinese is active (the existing language-switch rules).
+
+### Non-Goals
+
+- JNI, libpinyin/fcitx5, or any new native dependency.
+- Retraining CTC or adding a per-script ONNX encoder for Hanzi (the CTC emission head is
+  Latin/script slots, not a 20k-class Hanzi softmax).
+- Cloud input, telemetry, or network fetches. Ever.
+- A new keyboard layout or a second chrome; QWERTY + the existing suggestion bar.
+- Full sentence segmentation / smart phrase decoding in the first engine cut. The phrase
+  table may contain multi-syllable keys (`nihao`, `beijingdaxue`) so common phrases work;
+  general lattice segmentation is a follow-up.
+- Learning Hanzi choices into the n-gram model in the first cut.
+
+## Requirements
+
+### Functional Requirements
+
+1. **FR-1 Pack declaration**: a pack may declare `"inputMethod": "pinyin"` in
+   `manifest.json`. Absent means `"wordfreq"` (the legacy contract). Unknown values are
+   refused at import with a reason; they never silently degrade to wordfreq.
+2. **FR-2 Phrase table required**: a pinyin pack must carry `phrases.bin` (V1 `CKPY`).
+   Missing or malformed → import error. A `phrases.bin` present without the pinyin mode is
+   refused (nothing would read it; a silent drop turns a manifest typo into a broken
+   keyboard).
+3. **FR-3 Lookup**: the engine can answer exact (`nihao`) and prefix (`ni` → `ni`, `nian`,
+   `niang`, `nihao`) queries against the parsed table, in rank order.
+4. **FR-4 Tap composing**: typing `a–z`/`'` while pinyin mode is active appends to a session
+   buffer instead of committing letters. The preedit is visible to the user.
+5. **FR-5 Candidate selection**: the suggestion bar shows ranked Hanzi candidates for the
+   current buffer. Tapping one commits it; space commits the top candidate (configurable
+   later); enter commits the top candidate and runs the editor action.
+6. **FR-6 Backspace edits the buffer**: backspace deletes one pinyin character while the
+   session is non-empty; only when the buffer is empty does it reach the editor.
+7. **FR-7 Swipe does not auto-commit**: a swipe decodes to a pinyin surface, which enters
+   the session as preedit and refreshes candidates. The existing auto-insert of the top
+   swipe prediction is suppressed for pinyin. Tap/space commit, matching FR-5.
+8. **FR-8 `v` = `ü`, apostrophe disambiguates**: `nv` looks up `女` (the builder maps
+   `ü` → `v`); `xi'an` and `xian` are distinct keys. No tone digits are required; source
+   tone marks are stripped by the builder.
+9. **FR-9 Password/PIN bypass**: in a password/PIN/number field, pinyin mode is inert —
+   letters commit directly, no preedit, no candidates, no learning. `SuggestionBar`
+   password mode already owns this classification (`SuggestionBar.isPasswordField`).
+10. **FR-10 Isolation**: while the pinyin pack is the active primary language, English
+    candidates are not merged into the slate (same rule as the secondary-language merge),
+    and pinyin/Hanzi text never enters the English n-gram context.
+11. **FR-11 Failure behavior**: if the phrase table is absent/corrupt at runtime, the
+    keyboard falls back to committing the typed Latin letters (never a dead end) and the
+    settings support surface reports the pack as broken.
+
+### Non-Functional Requirements
+
+1. **NFR-1 Latency**: candidate lookup ≤ ~5 ms for a 500k-key table on mid-range hardware;
+   lookup is a binary search + contiguous scan, no per-keystroke table rebuild.
+2. **NFR-2 Memory**: the parsed table is bounded (≤ 64 MiB file, ≤ 1M keys, ≤ 512
+   candidates/key, ≤ 120 B key, ≤ 64 B candidate text) and is parsed once per pack
+   generation, not per keystroke.
+3. **NFR-3 Determinism**: key order (strictly ascending), candidate rank order
+   (non-decreasing), and the Python/Kotlin byte layouts agree by construction; a round-trip
+   test pins them.
+4. **NFR-4 Privacy**: 100 % on-device, no telemetry; pack import stays streaming (no whole
+   entry materialised) per the v1.1.96/v1.1.97 OOM fix.
+5. **NFR-5 No regression**: existing packs, dictionaries, and tests are untouched by the
+   new field; a pack without `inputMethod` parses and imports exactly as before.
+
+### User Stories
+
+- **As a** Simplified-Chinese typist, **I want** to type `nihao` and tap 你好, **so that** I
+  can write Chinese without leaving CleverKeys.
+- **As a** swipe typist, **I want** to swipe the pinyin spelling and pick from candidates,
+  **so that** I get the same speed as English swipe typing.
+- **As a** privacy-conscious user, **I want** password fields to bypass composition
+  entirely, **so that** nothing about my credentials is buffered or learned.
+
+## Pack Format (implemented in this PR)
+
+### Manifest
+
+`manifest.json` gains one optional field. Everything else is unchanged
+([`LanguagePackManager.parseManifest`](../../src/main/kotlin/tribixbite/cleverkeys/langpack/LanguagePackManager.kt)):
+
+```json
+{
+  "code": "zh",
+  "name": "中文（拼音）",
+  "version": 1,
+  "author": "",
+  "wordCount": 40000,
+  "hasPrefixBoost": false,
+  "inputMethod": "pinyin"
+}
+```
+
+| Field | Type | Default | Meaning |
+|---|---|---|---|
+| `inputMethod` | string | `"wordfreq"` | `"wordfreq"` = dictionary entries are the committed words (legacy, all existing packs). `"pinyin"` = composing pack; requires `phrases.bin`. |
+
+Key order is fixed by the builder (`scripts/build_langpack.py` writes `inputMethod` only
+for non-wordfreq packs) so existing packs stay byte-identical. The installed manifest
+round-trips: `LanguagePackManager.getInstalledPacks()` reports the mode.
+
+### Pack members
+
+| Member | Required | Notes |
+|---|---|---|
+| `manifest.json` | yes | as above |
+| `dictionary.bin` | yes | V2 `CKDT`; for pinyin packs its words are **pinyin spellings** (`nihao`, `xi'an`) so the swipe decoders can produce them. Ranks are pinyin frequency. |
+| `phrases.bin` | for pinyin | V1 `CKPY`; the conversion table. |
+| `unigrams.txt`, `contractions.json`, `prefix_boost.bin`, `model.onnx` | no | unchanged |
+
+The dictionary is still required so the pack remains a normal pack (and because the swipe
+decoders need a lexicon); `phrases.bin` is what makes the committed text Chinese.
+
+### CKPY v1 — pinyin phrase table
+
+Little-endian throughout, matching `CKDT`. Reader:
+[`pinyin/CkpyPhraseTable.kt`](../../src/main/kotlin/tribixbite/cleverkeys/pinyin/CkpyPhraseTable.kt).
+Writer: [`scripts/build_phrase_table.py`](../../scripts/build_phrase_table.py).
+
+```
+Header (48 bytes):
+  offset 0   magic       uint32   0x59504B43 = "CKPY"
+  offset 4   version     uint32   1
+  offset 8   language    char[4]  UTF-8 NUL-padded, e.g. "zh\0\0"
+  offset 12  keyCount    uint32   number of pinyin keys (>= 1)
+  offset 16  dataOffset  uint32   offset of the data section (48 in v1)
+  offset 20  reserved    byte[28] zeros
+
+Data section (at dataOffset), keyCount records in STRICTLY ASCENDING key order:
+  uint16 keyLength                       (1..120 UTF-8 bytes)
+  byte[keyLength] key                    (normalized: ^[a-z']+$)
+  uint16 candidateCount                  (1..512)
+  candidateCount candidate records:
+    uint16 textLength                    (1..64 UTF-8 bytes)
+    byte[textLength] text                (UTF-8; 汉字/漢字/phrase; no NUL/U+FFFD)
+    uint8 rank                           (0 = most preferred; non-decreasing)
+```
+
+Rules the reader enforces (all tested):
+
+- magic + version exact; `dataOffset` within the file and ≥ 48; no trailing bytes;
+- keys strictly ascending (byte order), so exact lookup and prefix runs are binary-searchable;
+- keys match `^[a-z']+$`; candidate ranks non-decreasing within a key;
+- every length checked before slicing; counts capped (anti-OOM for untrusted packs);
+- the reader streams with a 64 MiB ceiling rather than trusting a stream.
+
+`CkpyPhraseTable.Table` offers `lookup(key)` (exact) and `withPrefix(prefix)` (lower-bound
+binary search + contiguous forward scan). Ranks are engine-relative, never probabilities —
+the same convention as `CKDT`'s rank byte and `PredictionResult.scores`.
+
+### Key normalization (fixed at both ends)
+
+| Rule | Example |
+|---|---|
+| lowercase ASCII; only `a-z` and `'` | `NiHao` → `nihao` |
+| `ü` and the toned ü forms (`ǖǘǚǜ`) → `v` | `lü` → `lv`, 女 = `nv` |
+| other tone marks stripped (NFD, drop combining) | `nǐ` → `ni` |
+| digit tone numbers stripped | `ni3` → `ni` |
+| curly/backtick apostrophes → `'` | `xi’an` → `xi'an` |
+| `xi'an` stays distinct from `xian` | both are valid, different keys |
+
+### Builder pipeline
+
+```bash
+# 1. Phrase table: TSV `pinyin<TAB>text[<TAB>weight]`, grouped + rank-sorted by weight.
+python3 scripts/build_phrase_table.py --lang zh --input phrases.tsv --output phrases.bin
+
+# 2. Pack: dictionary.bin holds pinyin spellings (wordfreq words file of pinyin),
+#    phrases.bin holds the Hanzi candidates.
+python3 scripts/build_langpack.py --lang zh --name "中文（拼音）" \
+    --dict zh_pinyin.bin --input-method pinyin --phrases phrases.bin \
+    --output langpack-zh-Hans.zip
+```
+
+`build_langpack.py` refuses the same couplings the importer refuses: pinyin without a
+`phrases.bin`, a phrase table without the mode, a non-CKPY-v1 table, or a table over the
+64 MiB reader cap.
+
+### As-built test pins (this PR)
+
+| Behavior | Test |
+|---|---|
+| CKPY header bytes, record framing | `src/test/kotlin/tribixbite/cleverkeys/pinyin/CkpyPhraseTableTest.kt` (`headerFieldsPinTheCkpyV1Layout`, `recordFramingPinsLengthPrefixedUtf8AndRankBytes`) |
+| exact + prefix lookup, normalization | same file (`lookupIsExact`, `withPrefixReturnsTheContiguousRunInKeyOrder`, `lookupsRequireANormalizedQuery`) |
+| malformed tables refused | same file (magic/version/truncation/ordering/ranks/trailing/empty) |
+| manifest field, member carry, couplings | `src/test/kotlin/tribixbite/cleverkeys/langpack/LanguagePackImportTest.kt` (pinyin section: 5 tests) |
+
+## Runtime Design (planned — not in this PR)
+
+### Architecture
+
+```
+ tap a–z/' ─► KeyEventHandler.key_up ─► PinyinSession
+                                          │  buffer "nihao"
+                                          ├─► CkpyPhraseTable.withPrefix/lookup
+                                          │       → ranked 汉字 candidates
+                                          ▼
+                                     SuggestionBar (reused; already Unicode-capable)
+                                          │ tap / space
+                                          ▼
+                          InputConnection.commitText("你好", 1)
+
+ swipe ─► SwipeEngineRouter (geometric, or CTC once zh is served)
+              └─ decoded pinyin surface ─► same PinyinSession (preedit only, NO auto-commit)
+```
+
+### Components
+
+1. **`PinyinSession`** (`src/main/kotlin/tribixbite/cleverkeys/pinyin/`): owns the buffer,
+   the preedit state, and the candidate slate. Pure JVM except its commit calls, so the
+   state machine is unit-testable. API sketch:
+
+   ```kotlin
+   class PinyinSession(private val table: CkpyPhraseTable.Table) {
+       fun append(letter: Char)          // a-z, ' (and v for ü)
+       fun backspace(): Boolean          // true when it consumed the key
+       fun feedSwipe(pinyin: String)     // swipe surface; replaces/appends per policy
+       fun candidates(): List<String>    // ranked Hanzi, bounded
+       fun takeTop(): String?
+       fun reset()
+   }
+   ```
+
+2. **Phrase engine**: exact match on the buffer first; otherwise `withPrefix` results
+   flattened in (rank, key) order with text de-duplication. Multi-syllable keys in the
+   table give phrases (`nihao` → 你好); full segmentation is a follow-up.
+
+3. **Preedit / composing region**: the planned path uses
+   `InputConnection.setComposingText(preedit, 1)` while composing and `commitText(hanzi, 1)`
+   on selection (which implicitly finishes composing). This is net-new for this codebase —
+   production has **zero** composing calls today and
+   `SuggestionTapPartialReplaceTest` pins the English replace path to NOT use them. The
+   pinyin path is feature-gated, so those pins stay green. If device testing finds editors
+   that mishandle composing, the fallback is the existing commit-then-`deleteSurroundingText`
+   pattern behind the same `PinyinSession` API; the spec requires the fallback to be
+   validated on the maintainer's test phones before release.
+
+4. **Key interception** (planned, exact sites):
+   - `KeyEventHandler.key_up` `Kind.Char`/`Kind.String` dispatch
+     (`src/main/kotlin/tribixbite/cleverkeys/KeyEventHandler.kt:96-97`) — branch to the
+     session before `sendText` (`:323`) and its `commitText` (`:482`);
+   - backspace `KEYCODE_DEL` branch (`KeyEventHandler.kt:99-135`) — session first;
+   - suggestion tap → `SuggestionHandler.onSuggestionSelected` (`SuggestionHandler.kt:1501`)
+     — unchanged commit site, fed by pinyin candidates;
+   - swipe → `SuggestionHandler.handleSwipePredictionResults`
+     (`SuggestionHandler.kt:748-978`) — suppress the auto-insert at `:857-966` for pinyin
+     and route the decoded surface into the session.
+
+5. **Suggestion bar**: reuse as-is. It renders arbitrary `String`s
+   (`SuggestionBar.createSuggestionView:145`, `setSuggestionsWithScores:552`), already
+   honours password mode (`isPasswordField:924`, `setPasswordMode`), and has a
+   provenance/long-press surface for later.
+
+6. **Swipe serving**:
+   - geometric: works today — pinyin letters project onto QWERTY
+     (`GeometricEngineAdapter.dictionaryFor:585` reads the pack's CKDT);
+   - CTC: optional follow-up — add a `zh` row to `CtcLanguageSupport.SUPPORTED`
+     (`swipe/ctc/CtcLanguageSupport.kt:123`) sourced from the pack's pinyin-spelled CKDT;
+     the Latin encoder is layout-agnostic. Given there is **no pinyin swipe corpus**, the
+     row would be PROVISIONAL-tier by the table's own honesty conventions, and the
+     conversion stage hooks at `CtcEngineAdapter.decodeLexicon:1087` /
+     `applyDisplay:943` where accents and contractions already restore display forms.
+
+7. **Mode selection / language plumbing**: pinyin mode is chosen by the active primary
+   language's installed pack declaring `inputMethod: "pinyin"`. `PreferenceUIUpdateHandler`
+   already reloads predictors on language change. Note two existing guards: `LanguageDetector`
+   has no `zh` profile (`LanguageDetector.kt:42-199`, `:373-382`) and
+   `PredictionContextTracker` intentionally bails on CJK cursor sync
+   (`PredictionContextTracker.kt:870-876`); auto-detection must never silently switch into
+   pinyin mode — explicit selection only in P1.
+
+### Privacy and security
+
+- No network permission is involved; everything is on-device.
+- Password/PIN: classification already exists (`SuggestionBar.isPasswordField`,
+  `CleverKeysService.onStartInputView:705-720`, `SuggestionHandler.setPasswordMode`); pinyin
+  mode must check it in the same places the English path does, and must clear the session on
+  field change.
+- Learning: pinyin commits must respect `LearningGate.fieldAllowsPersonalizedLearning` and
+  `PrivacyManager` consent; P1 does not add user-selection learning at all.
+- Pack import: the new member flows through the existing staging + path-safety + streaming
+  machinery; the format reader bounds every untrusted length before use.
+
+## Testing Strategy
+
+- **Pure JVM** (`runPureTests`): `CkpyPhraseTableTest` — layout bytes, lookup, prefix,
+  malformed inputs, bounds. Runs in CI.
+- **Mock tier** (`runMockTests`): the five pinyin import tests in `LanguagePackImportTest` —
+  mode parsing, member carry, the two couplings, unknown modes, rejection cleanup.
+- **Python**: `build_phrase_table.py` verifies its own output by re-parsing it before
+  writing; `build_langpack.py` refuses the invalid combinations. A generated table is parsed
+  by the Kotlin reader during development (cross-tool round-trip exercised 2026-09-11:
+  Python writer → Kotlin reader, including `lü`→`lv` and `ni3`→`ni`).
+- **Engine phases** add: `PinyinSessionTest` (pure), commit-path tests alongside the
+  existing `SuggestionTapPartialReplaceTest` shapes, and instrumented pipeline tests for
+  the composing region on real editors.
+
+## Implementation Plan
+
+### Phase 0 — schema + container format (THIS PR)
+
+- [x] `docs/specs/pinyin-ime.md` (this document)
+- [x] `inputMethod` manifest field, `phrases.bin` member, validation + storage accessor
+- [x] `CKPY` v1 reader + unit tests; Python writer; `build_langpack.py` integration
+- [x] Index rows in `docs/specs/README.md` / `docs/TABLE_OF_CONTENTS.md`
+- [ ] Maintainer decision on the composing-region approach (open question Q1)
+
+### Phase 1 — tap-first engine
+
+- [ ] `PinyinSession` + candidate assembly, wired to `KeyEventHandler.key_up`
+- [ ] Suggestion bar candidate display; tap/space/enter commit; backspace editing
+- [ ] Password bypass; fallback-to-Latin on missing table
+- [ ] First real pack built (pinyin wordfreq spellings + open phrase source), device-tested
+
+### Phase 2 — swipe
+
+- [ ] Suppress auto-insert for pinyin; feed decoded surface into the session
+- [ ] Validate geometric pinyin swipe quality on device
+- [ ] Optional: `zh` row in `CtcLanguageSupport` (PROVISIONAL) once a corpus evaluation exists
+
+### Phase 3 — polish
+
+- [ ] `zh-Hans` / `zh-Hant` pack variants (shared pinyin keys; separate phrase tables)
+- [ ] Candidate ranking with context; user-selection learning behind the privacy gates
+- [ ] Segmentation/lattice decoding for unbounded input; settings surface for space behavior
+
+## Dependencies
+
+- No new libraries. Kotlin stdlib only for the reader; Python 3 stdlib for the writer.
+- Existing pieces reused: pack import/staging (`LanguagePackManager`), suggestion bar,
+  geometric/CTC adapters, password mode, preference reload plumbing.
+
+## Security Considerations
+
+- `phrases.bin` is untrusted input: every field is length-checked and capped before use;
+  the parse fails loudly rather than returning a truncated table.
+- Import remains header-only validation + streaming copy; the new member does not weaken the
+  v1.1.96 OOM fix (`LanguagePackImportTest.theImportPathNeverReadsAWholeEntryIntoMemory`
+  still scans `importFromStream`).
+- Unknown `inputMethod` values and orphan phrase tables are refused, so a pack cannot claim
+  a mode the app will misinterpret.
+
+## Error Handling
+
+| Scenario | Behavior |
+|---|---|
+| Missing/invalid `phrases.bin` on import | `ImportResult.Error` with a specific message; nothing installed |
+| Unknown `inputMethod` | refused at import with the value named |
+| Corrupt table at runtime | pinyin mode degrades to committing the raw Latin buffer; pack reported broken |
+| Table absent but pack selected | same degradation; English/normal behavior remains available |
+| Password/PIN field | session disabled before any buffer exists |
+
+## Open Questions
+
+1. **Composing region vs commit-and-replace**: use `setComposingText` (standard, better
+   editor UX, net-new in this codebase) or the repo's existing replace pattern? Recommend
+   composing, with a device-validation gate and the replace path as fallback. Needs the
+   maintainer's call before Phase 1.
+2. **Space behavior**: commit top candidate only, or commit top + trailing space (English
+   auto-space)? Chinese input convention is commit-without-space.
+3. **Pack code shape**: `zh` + name variants vs `zh-hans`/`zh-hant`; the import regex
+   accepts both (`^[a-z]{2,3}(?:[_-][a-z0-9]{1,16}){0,4}$`), but settings/SubtypeManager
+   display has no `zh` row yet.
+4. **Phrase data source/licence** for a distributable pack (e.g. Rime/librime dictionaries,
+   CC-CEDICT-derived pinyin data) — pack publication is a separate decision from the format.
+
+## Future Enhancements
+
+- Fuzzy pinyin (zh/z, ch/c, sh/s, n/l, front/back nasal) as a table-level variant key.
+- Simplified/Traditional toggle at runtime (two phrase tables; shared pinyin keys).
+- User phrase learning (selection counts) stored per language behind the learning gate.
+
+## References
+
+- Issue: tribixbite/CleverKeys#177
+- `src/main/kotlin/tribixbite/cleverkeys/pinyin/CkpyPhraseTable.kt` — reader, layout KDoc
+- `src/main/kotlin/tribixbite/cleverkeys/langpack/LanguagePackManager.kt` — manifest + import
+- `scripts/build_phrase_table.py`, `scripts/build_langpack.py` — writers
+- `docs/specs/ctc-architecture-and-multiscript-guide.md`,
+  `docs/specs/geometric-swipe-engine.md`, `docs/specs/secondary-language-integration.md`,
+  `docs/specs/password-field-mode.md`, `docs/specs/suggestion-bar-content-pane.md`
+
+---
+
+**Created**: 2026-09-11
+**Last Updated**: 2026-09-11
+**Owner**: Macho0x

--- a/docs/specs/pinyin-ime.md
+++ b/docs/specs/pinyin-ime.md
@@ -55,6 +55,9 @@ composing region) lands against a fixed schema instead of inventing one mid-impl
   table may contain multi-syllable keys (`nihao`, `beijingdaxue`) so common phrases work;
   general lattice segmentation is a follow-up.
 - Learning Hanzi choices into the n-gram model in the first cut.
+- Zhuyin/Bopomofo (and any other non-pinyin input method): this spec is pinyin only —
+  Simplified (`zh-Hans`) and Traditional (`zh-Hant`) both use the QWERTY pinyin engine with
+  their own phrase tables; Zhuyin would need its own layout and key mapping.
 
 ## Requirements
 

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -484,6 +484,7 @@
     <string name="provenance_origin_exact_add">Exact typed word (tap to add)</string>
     <string name="provenance_origin_next_word">Next-word prediction</string>
     <string name="provenance_origin_autocorrect">Autocorrect prompt</string>
+    <string name="provenance_origin_pinyin">Pinyin candidate</string>
     <string name="provenance_unknown">Unknown</string>
     <string name="provenance_source">Source: %1$s</string>
     <string name="provenance_score">Score: %1$d</string>

--- a/scripts/build_langpack.py
+++ b/scripts/build_langpack.py
@@ -3,12 +3,19 @@
 Build Language Pack ZIP for CleverKeys.
 
 Creates a language pack ZIP file containing:
-- manifest.json: metadata (language code, name, version)
+- manifest.json: metadata (language code, name, version, inputMethod)
 - dictionary.bin: V2 binary dictionary with accent normalization
+- phrases.bin: V1 CKPY pinyin phrase table (required for --input-method pinyin)
 - unigrams.txt: word frequency list for language detection
 - contractions.json: apostrophe word mappings (optional, for languages that use them)
 - prefix_boost.bin: Aho-Corasick trie for prefix boosting (optional, for non-English)
 - model.onnx: CTC swipe encoder for a non-Latin script (optional, --model)
+
+A composing pinyin pack (gh #177) carries `"inputMethod": "pinyin"` and a `phrases.bin`
+built by `build_phrase_table.py`. The app refuses a pinyin pack without the table, and
+refuses a table without the mode, so this script enforces the same coupling at build
+time. The CKDT dictionary is still required (the swipe path decodes pinyin spellings
+over it); it is the phrase table that supplies the committed 汉字.
 
 The six per-script CTC encoders (ru/el/uk/bg/mk/he) ship IN their packs rather
 than in the APK: every one of those languages is langpack-sourced, so the model
@@ -27,6 +34,8 @@ Usage:
     python3 build_langpack.py --lang de --name "German" --input german_words.txt --output langpack-de.zip --use-wordfreq
     python3 build_langpack.py --lang ru --name "Russian" --dict dictionary.bin --unigrams unigrams.txt \
         --model ru_synth_v3_ch80_fp16w.onnx --version 2 --output langpack-ru.zip
+    python3 build_langpack.py --lang zh --name "中文（拼音）" --dict zh_pinyin.bin \
+        --input-method pinyin --phrases phrases.bin --output langpack-zh-Hans.zip
 
 Prerequisites:
     - Run build_dictionary.py first to generate dictionary.bin
@@ -61,6 +70,15 @@ ZIP_EPOCH = (1980, 1, 1, 0, 0, 0)
 # Mirrors CtcPackModel.MAX_PACK_MODEL_BYTES. Enforced here too so a pack that the
 # app would refuse to import can never be built and published in the first place.
 MAX_MODEL_BYTES = 8 * 1024 * 1024
+
+# Mirrors CkpyPhraseTable.MAX_FILE_BYTES (private there): the reader refuses a larger
+# table, so refuse to build one.
+MAX_PHRASES_BYTES = 64 * 1024 * 1024
+
+# Mirrors CkpyPhraseTable.MAGIC / VERSION — a phrases.bin the app cannot read must fail
+# here, not at import time on a user's phone.
+CKPY_MAGIC = b"CKPY"
+CKPY_VERSION = 1
 
 
 def _add_deterministic(zf: zipfile.ZipFile, arcname: str, data: bytes) -> None:
@@ -159,12 +177,14 @@ def count_words_in_dictionary(dict_file: Path) -> int:
 
 
 def create_manifest(lang: str, name: str, version: int, author: str, word_count: int,
-                    has_prefix_boost: bool = False, model_sha256: str | None = None) -> dict:
+                    has_prefix_boost: bool = False, model_sha256: str | None = None,
+                    input_method: str = "wordfreq") -> dict:
     """Create manifest.json content.
 
     Key order is fixed (json.dump preserves insertion order) so the serialized
     manifest -- and therefore the whole archive -- stays a pure function of its
-    inputs. "model" goes last, so adding it does not perturb any existing pack.
+    inputs. "inputMethod" is written only for non-wordfreq packs, so every legacy
+    pack keeps its exact manifest bytes; "model" goes last.
     """
     manifest = {
         "code": lang,
@@ -174,6 +194,8 @@ def create_manifest(lang: str, name: str, version: int, author: str, word_count:
         "wordCount": word_count,
         "hasPrefixBoost": has_prefix_boost
     }
+    if input_method != "wordfreq":
+        manifest["inputMethod"] = input_method
     if model_sha256:
         manifest["model"] = {"file": "model.onnx", "sha256": model_sha256}
     return manifest
@@ -189,7 +211,9 @@ def build_langpack(
     use_wordfreq: bool = False,
     version: int = 1,
     author: str = "",
-    model_file: Path = None
+    model_file: Path = None,
+    input_method: str = "wordfreq",
+    phrases_file: Path = None
 ):
     """Build a language pack ZIP file."""
 
@@ -218,6 +242,28 @@ def build_langpack(
         # Validate required files
         if not final_dict or not final_dict.exists():
             print("Error: No dictionary.bin available. Provide --dict or --input")
+            return False
+
+        # The phrase table and the mode must travel together, exactly as the importer
+        # enforces: a pinyin pack without phrases.bin is refused at import, and a stray
+        # phrases.bin without the mode is refused too. Fail at build time instead.
+        phrases_bytes = None
+        if input_method == "pinyin":
+            if not phrases_file or not phrases_file.exists():
+                print("Error: --input-method pinyin requires --phrases phrases.bin "
+                      "(build it with build_phrase_table.py)")
+                return False
+            phrases_bytes = phrases_file.read_bytes()
+            if (len(phrases_bytes) < 48 or phrases_bytes[:4] != CKPY_MAGIC
+                    or int.from_bytes(phrases_bytes[4:8], byteorder="little") != CKPY_VERSION):
+                print(f"Error: --phrases {phrases_file} is not a CKPY v{CKPY_VERSION} table")
+                return False
+            if len(phrases_bytes) > MAX_PHRASES_BYTES:
+                print(f"Error: --phrases is {len(phrases_bytes)} B, over the "
+                      f"{MAX_PHRASES_BYTES} B limit the reader enforces")
+                return False
+        elif phrases_file:
+            print("Error: --phrases requires --input-method pinyin")
             return False
 
         # Get word count
@@ -253,7 +299,7 @@ def build_langpack(
 
         # Create manifest
         manifest = create_manifest(lang, name, version, author, word_count, has_prefix_boost,
-                                   model_sha256)
+                                   model_sha256, input_method)
         manifest_file = temp_path / "manifest.json"
         with open(manifest_file, 'w', encoding='utf-8') as f:
             json.dump(manifest, f, indent=2, ensure_ascii=False)
@@ -267,6 +313,9 @@ def build_langpack(
             "manifest.json": manifest_file.read_bytes(),
             "dictionary.bin": final_dict.read_bytes(),
         }
+        if phrases_bytes is not None:
+            entries["phrases.bin"] = phrases_bytes
+            print(f"  + phrases.bin ({len(phrases_bytes) / 1024:.1f} KB)")
         if final_unigrams and final_unigrams.exists():
             entries["unigrams.txt"] = final_unigrams.read_bytes()
             print(f"  + unigrams.txt")
@@ -300,6 +349,7 @@ def build_langpack(
         print(f"  File: {output}")
         print(f"  Size: {zip_size / 1024:.1f} KB")
         print(f"  Language: {name} ({lang})")
+        print(f"  Input method: {input_method}")
         print(f"  Words: {word_count}")
         print(f"  Prefix boost: {'Yes' if has_prefix_boost else 'No'}")
         print(f"  CTC model: {model_sha256 if model_sha256 else 'No'}")
@@ -328,6 +378,13 @@ def main():
                         help='CTC swipe encoder (.onnx) to ship as model.onnx. Only meaningful '
                              'for a script the app has a CtcScriptSupport row for -- the app '
                              'refuses any pack model that is not byte-identical to its pin.')
+    parser.add_argument('--input-method', choices=['wordfreq', 'pinyin'], default='wordfreq',
+                        help='How the pack is consumed. "pinyin" writes "inputMethod":"pinyin" '
+                             'and requires --phrases; the default keeps legacy manifests '
+                             'byte-identical.')
+    parser.add_argument('--phrases', type=Path,
+                        help='Pre-built CKPY phrases.bin (build_phrase_table.py). Required when '
+                             '--input-method is pinyin; refused otherwise.')
 
     args = parser.parse_args()
 
@@ -345,7 +402,9 @@ def main():
         use_wordfreq=args.use_wordfreq,
         version=args.version,
         author=args.author,
-        model_file=args.model
+        model_file=args.model,
+        input_method=args.input_method,
+        phrases_file=args.phrases
     )
 
     sys.exit(0 if success else 1)

--- a/scripts/build_phrase_table.py
+++ b/scripts/build_phrase_table.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""
+Build a CKPY v1 pinyin phrase table (`phrases.bin`) for a CleverKeys composing pack.
+
+The table maps a normalised toneless pinyin key to ranked candidate text (汉字 / 漢字):
+
+    ni<TAB>你<TAB>1000
+    ni<TAB>尼<TAB>20
+    nihao<TAB>你好<TAB>5000
+
+Input is TSV: `pinyin<TAB>text[<TAB>weight]`. One line per candidate; lines that share a
+pinyin key are grouped, sorted by weight DESC (input order breaks ties), and written in
+that order with rank = position (0 = most preferred). Missing weight defaults to 0.
+
+Key normalisation (the builder's job — the reader requires already-normalised keys):
+  - lowercased; `ü`/`ǖǘǚǜ` become `v` (女 = `nv`); other tone marks are stripped (NFD
+    + drop combining marks); digit tone numbers are dropped
+  - `’`/`‘`/`` ` `` become `'`; anything left that is not `a-z` or `'` is an error
+  - `xi'an` keeps its apostrophe, which is what disambiguates it from `xian`
+
+Format (little-endian, see `docs/specs/pinyin-ime.md` and `CkpyPhraseTable.kt`):
+  header 48 B: magic "CKPY" | version 1 | language 4 B NUL-padded | keyCount u32 |
+               dataOffset u32 = 48 | 28 B reserved zeros
+  per key:     keyLen u16 | key UTF-8 | candidateCount u16 |
+               per candidate: textLen u16 | text UTF-8 | rank u8
+
+Usage:
+    python3 build_phrase_table.py --lang zh --input phrases.tsv --output phrases.bin
+
+License: Apache-2.0
+"""
+
+import argparse
+import struct
+import sys
+import unicodedata
+from collections import OrderedDict
+from pathlib import Path
+
+MAGIC = 0x59504B43  # "CKPY" little-endian
+VERSION = 1
+HEADER_SIZE = 48
+LANGUAGE_BYTES = 4
+
+MAX_KEY_COUNT = 1_000_000
+MAX_KEY_BYTES = 120
+MAX_CANDIDATES_PER_KEY = 512
+MAX_TEXT_BYTES = 64
+
+# Precomposed u-umlaut forms must map to `v` BEFORE NFD strips the diaeresis, or `nv`
+# (女) would silently become `nu` — a different syllable.
+_UMLAUT = str.maketrans({
+    "\u00fc": "v",  # ü
+    "\u01d6": "v",  # ǖ
+    "\u01d8": "v",  # ǘ
+    "\u01da": "v",  # ǚ
+    "\u01dc": "v",  # ǜ
+    "\u2019": "'",  # ’
+    "\u2018": "'",  # ‘
+    "`": "'",
+})
+
+
+class BuildError(Exception):
+    pass
+
+
+def normalise_key(raw: str) -> str:
+    key = raw.strip().translate(_UMLAUT).lower()
+    key = unicodedata.normalize("NFD", key)
+    key = "".join(ch for ch in key if not unicodedata.combining(ch))
+    key = "".join(ch for ch in key if not ch.isdigit())
+    if not key:
+        raise BuildError(f"empty pinyin key after normalisation: {raw!r}")
+    bad = sorted({ch for ch in key if not ("a" <= ch <= "z" or ch == "'")})
+    if bad:
+        raise BuildError(
+            f"pinyin key {raw!r} normalises to {key!r} which contains {bad!r}; "
+            "only lowercase a-z and ' are allowed"
+        )
+    if len(key.encode("utf-8")) > MAX_KEY_BYTES:
+        raise BuildError(f"pinyin key {key!r} exceeds {MAX_KEY_BYTES} UTF-8 bytes")
+    return key
+
+
+def load_candidates(input_file: Path):
+    """Parse the TSV into {key: [(text, weight)]} preserving first-seen order."""
+    grouped: "OrderedDict[str, list[tuple[str, float]]]" = OrderedDict()
+    with open(input_file, "r", encoding="utf-8") as f:
+        for lineno, line in enumerate(f, 1):
+            line = line.rstrip("\n")
+            if not line.strip() or line.lstrip().startswith("#"):
+                continue
+            parts = line.split("\t")
+            if len(parts) < 2:
+                raise BuildError(f"{input_file}:{lineno}: expected `pinyin<TAB>text[<TAB>weight]`")
+            key = normalise_key(parts[0])
+            text = parts[1].strip()
+            if not text:
+                raise BuildError(f"{input_file}:{lineno}: empty candidate text")
+            if "\x00" in text:
+                raise BuildError(f"{input_file}:{lineno}: candidate text contains NUL")
+            if len(text.encode("utf-8")) > MAX_TEXT_BYTES:
+                raise BuildError(f"{input_file}:{lineno}: {text!r} exceeds {MAX_TEXT_BYTES} UTF-8 bytes")
+            weight = 0.0
+            if len(parts) >= 3 and parts[2].strip():
+                try:
+                    weight = float(parts[2])
+                except ValueError:
+                    raise BuildError(f"{input_file}:{lineno}: bad weight {parts[2]!r}") from None
+            grouped.setdefault(key, []).append((text, weight))
+    if not grouped:
+        raise BuildError(f"{input_file}: no phrase rows found")
+    if len(grouped) > MAX_KEY_COUNT:
+        raise BuildError(f"{len(grouped)} keys exceeds the {MAX_KEY_COUNT} format cap")
+    return grouped
+
+
+def rank_candidates(candidates):
+    """Stable weight-descending sort; rank = position, clamped to the uint8 range."""
+    ordered = sorted(candidates, key=lambda pair: -pair[1])
+    if len(ordered) > MAX_CANDIDATES_PER_KEY:
+        raise BuildError(
+            f"one key has {len(ordered)} candidates, over the {MAX_CANDIDATES_PER_KEY} format cap"
+        )
+    return [(text, min(index, 255)) for index, (text, _) in enumerate(ordered)]
+
+
+def build_table(language: str, grouped) -> bytes:
+    lang_bytes = language.encode("utf-8")
+    if len(lang_bytes) > LANGUAGE_BYTES:
+        raise BuildError(f"language tag {language!r} does not fit in {LANGUAGE_BYTES} UTF-8 bytes")
+    lang_bytes = lang_bytes.ljust(LANGUAGE_BYTES, b"\x00")
+
+    body = bytearray()
+    for key in sorted(grouped):
+        key_bytes = key.encode("utf-8")
+        candidates = rank_candidates(grouped[key])
+        body += struct.pack("<H", len(key_bytes)) + key_bytes + struct.pack("<H", len(candidates))
+        for text, rank in candidates:
+            text_bytes = text.encode("utf-8")
+            body += struct.pack("<H", len(text_bytes)) + text_bytes + struct.pack("<B", rank)
+
+    header = struct.pack(
+        "<II4sII", MAGIC, VERSION, lang_bytes, len(grouped), HEADER_SIZE
+    ) + b"\x00" * 28
+    return bytes(header) + bytes(body)
+
+
+def verify_table(data: bytes) -> None:
+    """Parse the bytes we just wrote back out, so a writer bug fails the build, not the app."""
+    if len(data) < HEADER_SIZE:
+        raise BuildError("written table is shorter than the header")
+    magic, version, lang, key_count, data_offset = struct.unpack_from("<II4sII", data, 0)
+    if magic != MAGIC or version != VERSION:
+        raise BuildError("written table header does not round-trip")
+    pos = data_offset
+    previous = None
+    for _ in range(key_count):
+        (key_len,) = struct.unpack_from("<H", data, pos)
+        pos += 2
+        key = data[pos:pos + key_len].decode("utf-8")
+        pos += key_len
+        if previous is not None and key <= previous:
+            raise BuildError(f"written keys not strictly ascending at {key!r}")
+        previous = key
+        (candidate_count,) = struct.unpack_from("<H", data, pos)
+        pos += 2
+        last_rank = -1
+        for _ in range(candidate_count):
+            (text_len,) = struct.unpack_from("<H", data, pos)
+            pos += 2 + text_len
+            rank = data[pos]
+            pos += 1
+            if rank < last_rank:
+                raise BuildError(f"written ranks out of order for {key!r}")
+            last_rank = rank
+    if pos != len(data):
+        raise BuildError(f"written table has {len(data) - pos} trailing bytes")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Build a CKPY v1 pinyin phrase table for CleverKeys",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument("--lang", default="zh", help='language tag stored in the header (default: zh)')
+    parser.add_argument("--input", required=True, type=Path,
+                        help="TSV source: `pinyin<TAB>text[<TAB>weight]` per line")
+    parser.add_argument("--output", required=True, type=Path, help="output phrases.bin path")
+    args = parser.parse_args()
+
+    try:
+        grouped = load_candidates(args.input)
+        data = build_table(args.lang, grouped)
+        verify_table(data)
+    except BuildError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        return 1
+
+    args.output.write_bytes(data)
+    candidate_count = sum(len(v) for v in grouped.values())
+    print(f"Wrote {args.output}")
+    print(f"  Language:   {args.lang}")
+    print(f"  Keys:       {len(grouped)}")
+    print(f"  Candidates: {candidate_count}")
+    print(f"  Size:       {len(data) / 1024:.1f} KB")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/main/kotlin/tribixbite/cleverkeys/CleverKeysService.kt
+++ b/src/main/kotlin/tribixbite/cleverkeys/CleverKeysService.kt
@@ -23,6 +23,7 @@ import android.view.inputmethod.InputMethodSubtype
 import android.widget.FrameLayout
 import android.widget.LinearLayout
 import tribixbite.cleverkeys.ml.SwipeMLData
+import tribixbite.cleverkeys.pinyin.PinyinController
 
 /**
  * Main InputMethodService implementation for Unexpected Keyboard.
@@ -135,6 +136,10 @@ class CleverKeysService : InputMethodService(),
 
     // Suggestion/prediction bridge (v1.32.406: extracted to SuggestionBridge)
     private lateinit var _suggestionBridge: SuggestionBridge
+
+    // gh #177: pinyin composing controller. Created in onCreate once the graph exists;
+    // consulted by the key-event bridge, the suggestion bridge, and the input lifecycle.
+    private var _pinyinController: PinyinController? = null
 
 
     // Layout bridge (v1.32.408: extracted to LayoutBridge)
@@ -435,6 +440,18 @@ class CleverKeysService : InputMethodService(),
         // Suggestion bridge (v1.32.406: extracted to SuggestionBridge; built by the graph)
         _suggestionBridge = _graph.suggestionBridge
 
+        // gh #177: pinyin composing mode. Created after the graph (needs config + the
+        // suggestion bar provider), then handed to the key-event bridge and the swipe
+        // pipeline. Inactive until a pinyin pack is the active primary language.
+        _pinyinController = PinyinController.create(
+            context = this,
+            languageProvider = { _config?.primary_language },
+            inputConnectionProvider = { currentInputConnection },
+            suggestionBarProvider = { _suggestionBar },
+        )
+        _receiverBridge.setPinyinController(_pinyinController)
+        _suggestionHandler.setPinyinHook(_pinyinController)
+
         // Wire the view's service handle (unconditional) and load prediction models if enabled
         _graph.wireSwipeTypingComponents()
 
@@ -706,6 +723,9 @@ class CleverKeysService : InputMethodService(),
             val isPasswordField = SuggestionBar.isPasswordField(info)
             _suggestionBar?.setPasswordMode(isPasswordField)
             _suggestionHandler?.setPasswordMode(isPasswordField)
+            // gh #177: pinyin composing is off in password/PIN fields; otherwise this is
+            // where the active language's pack decides whether the mode turns on.
+            _pinyinController?.onStartInputView(isPasswordField)
 
             // M5 (review 2026-08-06): honor IME_FLAG_NO_PERSONALIZED_LEARNING —
             // incognito fields (private browser tabs etc.) suppress the learn
@@ -801,6 +821,9 @@ class CleverKeysService : InputMethodService(),
     override fun onFinishInputView(finishingInput: Boolean) {
         super.onFinishInputView(finishingInput)
         _keyboardView.reset()
+
+        // gh #177: cancel any pinyin composing run before the field goes away.
+        _pinyinController?.onFinishInputView()
 
         // Clear suggestions to prevent stale state/crashes on app switch
         _suggestionBar?.clearSuggestions()
@@ -912,6 +935,12 @@ class CleverKeysService : InputMethodService(),
     fun getConfig(): Config? {
         return _config
     }
+
+    /**
+     * gh #177: the pinyin composing controller, or null before [onCreate] finishes wiring.
+     * Consumed by [SuggestionBridge] to route candidate taps into the composing session.
+     */
+    fun pinyinController(): PinyinController? = _pinyinController
 
     // v1.32.349: showDateFilterDialog() moved to ClipboardManager (now showFilterDialog())
 

--- a/src/main/kotlin/tribixbite/cleverkeys/KeyEventHandler.kt
+++ b/src/main/kotlin/tribixbite/cleverkeys/KeyEventHandler.kt
@@ -93,8 +93,12 @@ class KeyEventHandler(
         updateMetaState(mods)
 
         when (key.getKind()) {
-            KeyValue.Kind.Char -> sendText(key.getChar().toString(), isKeyRepeat)
-            KeyValue.Kind.String -> sendText(key.getString(), isKeyRepeat)
+            // gh #177: a pinyin composing session consumes letters/space before the normal
+            // commit path (and before autocap/TSR/context tracking — full isolation).
+            KeyValue.Kind.Char ->
+                if (!recv.pinyinHandleText(key.getChar().toString())) sendText(key.getChar().toString(), isKeyRepeat)
+            KeyValue.Kind.String ->
+                if (!recv.pinyinHandleText(key.getString())) sendText(key.getString(), isKeyRepeat)
             KeyValue.Kind.Event -> recv.handle_event_key(key.getEvent())
             KeyValue.Kind.Keyevent -> {
                 // Audit A-5: backspace invalidates the double-space-to-period memory — the
@@ -120,6 +124,14 @@ class KeyEventHandler(
                 // Arrow keys and Enter in clipboard edit mode — dispatch to inline EditText
                 } else if (recv.isClipboardEditMode() && key.getKeyevent() in EDIT_MODE_DISPATCH_KEYS) {
                     recv.dispatchKeyToClipboardEdit(key.getKeyevent())
+                // gh #177: pinyin composing owns backspace while its buffer is non-empty.
+                } else if (key.getKeyevent() == KeyEvent.KEYCODE_DEL && recv.pinyinHandleBackspace()) {
+                    // Consumed by the composing session (buffer shortened).
+                // gh #177: Escape cancels composing; Enter commits the top candidate but is
+                // not consumed here, so the editor action still fires below.
+                } else if (key.getKeyevent() != KeyEvent.KEYCODE_DEL &&
+                        recv.pinyinHandleKeyevent(key.getKeyevent())) {
+                    // Consumed by the composing session.
                 } else if (key.getKeyevent() == KeyEvent.KEYCODE_DEL && handleBackspaceUndoSwipe()) {
                     // #110: Backspace after swipe deletes entire swiped word
                 } else if (key.getKeyevent() == KeyEvent.KEYCODE_DEL && handleBackspaceUndoAutocorrect()) {
@@ -1042,6 +1054,11 @@ class KeyEventHandler(
         fun handle_text_typed(text: String)
         fun handle_backspace() {} // Default implementation for backward compatibility
         fun handle_delete_last_word() {} // Delete last auto-inserted or typed word
+        // gh #177: pinyin composing hooks. Defaults keep every non-pinyin build/behaviour
+        // untouched; the receiver returns true only while a composing session owns input.
+        fun pinyinHandleText(text: String): Boolean = false
+        fun pinyinHandleBackspace(): Boolean = false
+        fun pinyinHandleKeyevent(keyCode: Int): Boolean = false
         // Clipboard search mode methods
         fun isClipboardSearchMode(): Boolean = false // Check if clipboard search mode is active
         fun appendToClipboardSearch(text: String) {} // Append text to clipboard search box

--- a/src/main/kotlin/tribixbite/cleverkeys/SuggestionBar.kt
+++ b/src/main/kotlin/tribixbite/cleverkeys/SuggestionBar.kt
@@ -419,6 +419,7 @@ class SuggestionBar : LinearLayout {
         SuggestionOrigin.EXACT_ADD -> 0xFFB0BEC5.toInt()         // gray
         SuggestionOrigin.NEXT_WORD -> 0xFFA5D6A7.toInt()         // green
         SuggestionOrigin.AUTOCORRECT -> 0xFFEF9A9A.toInt()       // red
+        SuggestionOrigin.PINYIN -> 0xFFFFAB91.toInt()            // deep orange (汉字 composing)
     }
 
     /** Task B: register the long-press provenance inspection listener. */

--- a/src/main/kotlin/tribixbite/cleverkeys/SuggestionHandler.kt
+++ b/src/main/kotlin/tribixbite/cleverkeys/SuggestionHandler.kt
@@ -12,6 +12,7 @@ import android.view.inputmethod.InputConnection
 import tribixbite.cleverkeys.ml.PlaygroundTraceRecorder
 import tribixbite.cleverkeys.ml.SwipeMLData
 import tribixbite.cleverkeys.autocorrect.AutocorrectContextGuard
+import tribixbite.cleverkeys.pinyin.PinyinComposingHook
 import tribixbite.cleverkeys.swipe.SwipeContextRescorer
 import tribixbite.cleverkeys.swipe.ctc.CtcLanguageSupport
 
@@ -434,6 +435,16 @@ class SuggestionHandler(
     @Volatile
     private var nextWordSuggestionsActive = false
 
+    // gh #177: pinyin composing seam, late-bound by CleverKeysService. Non-null only after
+    // the service creates the controller; a swipe that decodes to pinyin spelling routes
+    // into the session instead of the English auto-insert path.
+    private var pinyinHook: PinyinComposingHook? = null
+
+    /** gh #177: install the pinyin composing hook (cleared by passing null). */
+    fun setPinyinHook(hook: PinyinComposingHook?) {
+        pinyinHook = hook
+    }
+
     // M5 (review 2026-08-06): incognito-field contract. False while the active
     // editor sets IME_FLAG_NO_PERSONALIZED_LEARNING — suppresses the learn
     // funnel, selection-adaptation recording, and next-word surfacing for that
@@ -511,7 +522,8 @@ class SuggestionHandler(
                 SuggestionOrigin.POSSESSIVE to text(R.string.provenance_origin_possessive),
                 SuggestionOrigin.EXACT_ADD to text(R.string.provenance_origin_exact_add),
                 SuggestionOrigin.NEXT_WORD to text(R.string.provenance_origin_next_word),
-                SuggestionOrigin.AUTOCORRECT to text(R.string.provenance_origin_autocorrect)
+                SuggestionOrigin.AUTOCORRECT to text(R.string.provenance_origin_autocorrect),
+                SuggestionOrigin.PINYIN to text(R.string.provenance_origin_pinyin)
             ),
             unknown = text(R.string.provenance_unknown),
             source = text(R.string.provenance_source),
@@ -759,6 +771,15 @@ class SuggestionHandler(
     ) {
         // Swipe results replace whatever the bar shows — any next-word display state ends here.
         nextWordSuggestionsActive = false
+
+        // gh #177: in pinyin composing mode the decoded surface IS the pinyin spelling, not
+        // a word to commit. Buffer it, refresh the 汉字 candidates, and stop — the spec's
+        // "do not auto-commit" rule. No context rescore, no English bar, no ML capture.
+        // Checked before the password/empty guards: an empty decode must leave the
+        // composing preedit and its candidates alone, not clear the bar.
+        pinyinHook?.let { hook ->
+            if (hook.onSwipeDecoded(predictions ?: emptyList(), scores ?: emptyList())) return
+        }
 
         // D2: password-field guard. Detect from the tracked mode OR the live editor (the latter holds
         // in tests / before onStartInputView sets the mode). Suppress the swipe unless the user opted in.

--- a/src/main/kotlin/tribixbite/cleverkeys/SuggestionProvenance.kt
+++ b/src/main/kotlin/tribixbite/cleverkeys/SuggestionProvenance.kt
@@ -49,7 +49,13 @@ enum class SuggestionOrigin {
     NEXT_WORD,
 
     /** Autocorrect undo prompt (original + corrected word after an autocorrect). */
-    AUTOCORRECT;
+    AUTOCORRECT,
+
+    /**
+     * Pinyin composing-session candidate (gh #177): a 汉字/漢字 form offered for the
+     * current pinyin buffer. Scored by the phrase table's rank, not the unified scorer.
+     */
+    PINYIN;
 
     companion object {
         /**

--- a/src/main/kotlin/tribixbite/cleverkeys/langpack/LanguagePackManager.kt
+++ b/src/main/kotlin/tribixbite/cleverkeys/langpack/LanguagePackManager.kt
@@ -580,6 +580,18 @@ class LanguagePackManager(private val context: Context) {
     }
 
     /**
+     * The manifest of the installed pack [code], or null when no such pack is installed.
+     *
+     * Unlike [getInstalledPacks] this reads exactly one directory, so a per-language mode
+     * check (does this pack want the pinyin composing engine?) does not re-parse every
+     * installed manifest. The input method's `inputMethod` field is on the returned model.
+     */
+    fun getInstalledPack(code: String): LanguagePackManifest? {
+        val manifestFile = File(langpacksDir, "$code/$MANIFEST_FILE")
+        return if (manifestFile.exists()) parseManifest(manifestFile.readText()) else null
+    }
+
+    /**
      * Delete a language pack.
      */
     fun deletePack(code: String): Boolean {

--- a/src/main/kotlin/tribixbite/cleverkeys/langpack/LanguagePackManager.kt
+++ b/src/main/kotlin/tribixbite/cleverkeys/langpack/LanguagePackManager.kt
@@ -9,14 +9,17 @@ import java.io.File
 import java.io.FileOutputStream
 import java.io.InputStream
 import java.util.zip.ZipInputStream
+import tribixbite.cleverkeys.pinyin.CkpyPhraseTable
 import tribixbite.cleverkeys.swipe.ctc.CtcPackModel
 
 /**
  * Language Pack Manager - handles import, validation, and storage of language packs.
  *
  * Language packs are ZIP files containing:
- * - manifest.json: metadata (language code, name, version, hasPrefixBoost)
+ * - manifest.json: metadata (language code, name, version, inputMethod, hasPrefixBoost)
  * - dictionary.bin: V2 binary dictionary with accent normalization
+ * - phrases.bin: optional V1 `CKPY` pinyin phrase table (pinyin key -> ranked 汉字), required
+ *   exactly when the manifest declares `"inputMethod": "pinyin"` (see "Composing IME packs")
  * - unigrams.txt: word frequency list for language detection
  * - contractions.json: optional apostrophe word mappings (e.g., "cest" -> "c'est")
  * - prefix_boost.bin: optional Aho-Corasick trie for prefix boosting. Its only consumer,
@@ -48,6 +51,27 @@ import tribixbite.cleverkeys.swipe.ctc.CtcPackModel
  * must not fill the cache dir before anything looks at its size), and hence an UNDECLARED
  * `model.onnx` being dropped rather than rejected: nothing can verify it, gate 2 would refuse
  * it anyway, and failing the whole import would punish the user for a stray file.
+ *
+ * ## Composing IME packs (`inputMethod`)
+ *
+ * A normal pack's dictionary entries ARE the text the keyboard commits. A composing IME
+ * (pinyin today) breaks that assumption: the user types keys and chooses 汉字, so the pack
+ * declares how its content is consumed. The manifest's optional `inputMethod` field carries
+ * that declaration:
+ *
+ *  - absent / `"wordfreq"` — the legacy contract. The bundled dictionaries and every pack
+ *    built before this field existed parse exactly as before.
+ *  - `"pinyin"` — a composing pack. It MUST carry `phrases.bin`, a V1 `CKPY` table mapping a
+ *    toneless pinyin key (`"nihao"`) to ranked candidate text (`你好` / 妳好). The reader is
+ *    [CkpyPhraseTable] and the format is specified in `docs/specs/pinyin-ime.md`. The pack's
+ *    `dictionary.bin` still ships (the swipe path decodes pinyin spellings over it), but the
+ *    keyboard's committed text comes from the phrase table, never from the key letters.
+ *
+ * Unknown `inputMethod` values are REFUSED rather than ignored: a pack built for a future
+ * mode must fail with a reason on an app that cannot honour the mode, not silently degrade
+ * into a wordfreq lexicon whose "words" are pinyin spellings. A `phrases.bin` present without
+ * `"inputMethod": "pinyin"` is refused for the same reason (nothing would read it, and a
+ * silent drop would turn a typo in the manifest into a broken keyboard).
  */
 class LanguagePackManager(private val context: Context) {
 
@@ -56,9 +80,25 @@ class LanguagePackManager(private val context: Context) {
         private const val LANGPACKS_DIR = "langpacks"
         private const val MANIFEST_FILE = "manifest.json"
         private const val DICTIONARY_FILE = "dictionary.bin"
+        private const val PHRASES_FILE = "phrases.bin"
         private const val UNIGRAMS_FILE = "unigrams.txt"
         private const val CONTRACTIONS_FILE = "contractions.json"
         private const val PREFIX_BOOST_FILE = "prefix_boost.bin"
+
+        /**
+         * `inputMethod` value for the legacy contract: dictionary entries are the committed
+         * words. Every pack without the field imports as this, so old packs are untouched.
+         */
+        const val INPUT_METHOD_WORDFREQ = "wordfreq"
+
+        /**
+         * `inputMethod` value for a composing pinyin pack. Requires a `phrases.bin` `CKPY`
+         * table; see the class KDoc ("Composing IME packs").
+         */
+        const val INPUT_METHOD_PINYIN = "pinyin"
+
+        /** Every `inputMethod` this app can honour; anything else is an import error. */
+        val SUPPORTED_INPUT_METHODS = setOf(INPUT_METHOD_WORDFREQ, INPUT_METHOD_PINYIN)
 
         /**
          * The pack's optional CTC encoder. Name and size cap come from [CtcPackModel] so the
@@ -173,6 +213,27 @@ class LanguagePackManager(private val context: Context) {
             val manifest = parseManifest(manifestFile.readText())
                 ?: return ImportResult.Error("Invalid manifest.json format")
 
+            // The pack's declared input method decides what else must be present. Unknown
+            // values are refused (see "Composing IME packs") rather than treated as wordfreq.
+            if (manifest.inputMethod !in SUPPORTED_INPUT_METHODS) {
+                return ImportResult.Error("Unsupported inputMethod \"${manifest.inputMethod}\"")
+            }
+            val phrasesFile = File(tempDir, PHRASES_FILE)
+            if (manifest.inputMethod == INPUT_METHOD_PINYIN) {
+                if (PHRASES_FILE !in extractedFiles) {
+                    return ImportResult.Error(
+                        "Missing $PHRASES_FILE for inputMethod \"$INPUT_METHOD_PINYIN\""
+                    )
+                }
+                if (!validatePhraseTable(phrasesFile)) {
+                    return ImportResult.Error("Invalid $PHRASES_FILE format")
+                }
+            } else if (phrasesFile.exists()) {
+                return ImportResult.Error(
+                    "$PHRASES_FILE requires inputMethod \"$INPUT_METHOD_PINYIN\""
+                )
+            }
+
             // Validate dictionary binary
             val dictFile = File(tempDir, DICTIONARY_FILE)
             if (!validateDictionary(dictFile)) {
@@ -227,6 +288,12 @@ class LanguagePackManager(private val context: Context) {
             stagingDir.mkdirs()
             try {
                 dictFile.copyTo(File(stagingDir, DICTIONARY_FILE), overwrite = true)
+
+                // Copy the pinyin phrase table for a composing pack (validated above).
+                if (manifest.inputMethod == INPUT_METHOD_PINYIN) {
+                    phrasesFile.copyTo(File(stagingDir, PHRASES_FILE), overwrite = true)
+                    Log.d(TAG, "Copied $PHRASES_FILE for ${manifest.code} (${phrasesFile.length() / 1024}KB)")
+                }
 
                 // Copy unigrams if present
                 val unigramsFile = File(tempDir, UNIGRAMS_FILE)
@@ -298,6 +365,9 @@ class LanguagePackManager(private val context: Context) {
                 hasPrefixBoost = obj.optBoolean("hasPrefixBoost", false),
                 modelFile = model?.optString("file")?.takeIf { it.isNotEmpty() },
                 modelSha256 = model?.optString("sha256")?.takeIf { it.isNotEmpty() },
+                // Absent in every pack built before the field existed — those must import
+                // exactly as they always did, i.e. as wordfreq packs.
+                inputMethod = obj.optString("inputMethod", INPUT_METHOD_WORDFREQ),
             )
         } catch (e: Exception) {
             Log.e(TAG, "Failed to parse manifest", e)
@@ -380,6 +450,41 @@ class LanguagePackManager(private val context: Context) {
     }
 
     /**
+     * Validate a `phrases.bin` pinyin phrase table: V1 `CKPY` magic + version.
+     *
+     * The importer checks the fixed header only — exactly like [validateDictionary] — because
+     * the pack entry must never be materialised whole (the v1.1.96/v1.1.97 OOM fix). Full
+     * structural parsing belongs to [CkpyPhraseTable], which streams with its own bounds.
+     */
+    private fun validatePhraseTable(file: File): Boolean {
+        if (!file.exists() || file.length() < CkpyPhraseTable.HEADER_SIZE) {
+            return false
+        }
+
+        return try {
+            file.inputStream().use { fis ->
+                val header = ByteArray(8)
+                if (fis.read(header) != 8) return false
+
+                val magic = (header[0].toInt() and 0xFF) or
+                           ((header[1].toInt() and 0xFF) shl 8) or
+                           ((header[2].toInt() and 0xFF) shl 16) or
+                           ((header[3].toInt() and 0xFF) shl 24)
+
+                val version = (header[4].toInt() and 0xFF) or
+                             ((header[5].toInt() and 0xFF) shl 8) or
+                             ((header[6].toInt() and 0xFF) shl 16) or
+                             ((header[7].toInt() and 0xFF) shl 24)
+
+                magic == CkpyPhraseTable.MAGIC && version == CkpyPhraseTable.VERSION
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "Phrase table validation failed", e)
+            false
+        }
+    }
+
+    /**
      * Get list of installed language packs.
      */
     fun getInstalledPacks(): List<LanguagePackManifest> {
@@ -405,6 +510,19 @@ class LanguagePackManager(private val context: Context) {
     fun getDictionaryPath(code: String): File? {
         val dictFile = File(langpacksDir, "$code/$DICTIONARY_FILE")
         return if (dictFile.exists()) dictFile else null
+    }
+
+    /**
+     * Path to an installed pinyin pack's `phrases.bin` phrase table, or null when the pack
+     * has none (every non-pinyin pack today). The reader is [CkpyPhraseTable.read].
+     *
+     * Like [getModelPath], this is a storage accessor, not a loader: it says the file is
+     * present, not that the app will use it (that decision belongs to the composing engine
+     * once one exists — see `docs/specs/pinyin-ime.md`).
+     */
+    fun getPhrasesPath(code: String): File? {
+        val phrasesFile = File(langpacksDir, "$code/$PHRASES_FILE")
+        return if (phrasesFile.exists()) phrasesFile else null
     }
 
     /**
@@ -517,6 +635,13 @@ data class LanguagePackManifest(
      * pinned hash (`CtcPackModel`), which trusts nothing in this field.
      */
     val modelSha256: String? = null,
+    /**
+     * How this pack's content is consumed. [LanguagePackManager.INPUT_METHOD_WORDFREQ]
+     * (the default, including every pack built before the field existed) means dictionary
+     * entries are the committed words; [LanguagePackManager.INPUT_METHOD_PINYIN] means a
+     * composing pack whose committed text comes from a `phrases.bin` `CKPY` table.
+     */
+    val inputMethod: String = LanguagePackManager.INPUT_METHOD_WORDFREQ,
 )
 
 /**

--- a/src/main/kotlin/tribixbite/cleverkeys/pinyin/CkpyPhraseTable.kt
+++ b/src/main/kotlin/tribixbite/cleverkeys/pinyin/CkpyPhraseTable.kt
@@ -1,0 +1,241 @@
+package tribixbite.cleverkeys.pinyin
+
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.io.InputStream
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Pure-JVM reader for the CleverKeys V1 `CKPY` pinyin phrase table: a 1:N map from a
+ * toneless pinyin key (`"nihao"`, `"xi'an"`) to ranked candidate text (汉字 / 漢字).
+ * This is the conversion layer a Pinyin IME needs and that `CKDT` cannot express —
+ * `CKDT` stores one display word per lookup key, while one pinyin key has many
+ * candidate words, each with its own preference rank.
+ *
+ * The companion writer is `scripts/build_phrase_table.py`; the pack-level plumbing
+ * (`inputMethod` manifest field, `phrases.bin` member, import validation) lives in
+ * [tribixbite.cleverkeys.langpack.LanguagePackManager]. Format rationale and the
+ * engine plan are in `docs/specs/pinyin-ime.md`.
+ *
+ * ## V1 header (48 bytes, little-endian)
+ *  - magic `CKPY` (4) · version 1 (4) · language 4 (UTF-8, NUL-padded, e.g. `"zh"`)
+ *  - keyCount uint32 (4) · dataOffset uint32 (4) · reserved 28 bytes (zeros)
+ *
+ * ## Data section (at `dataOffset`), `keyCount` records
+ * Keys are stored in STRICTLY ASCENDING byte order; one record is:
+ *  - length uint16 · UTF-8 bytes · candidateCount uint16
+ *  - then candidateCount candidate records:
+ *      - length uint16 · UTF-8 bytes · rank uint8 (0 = most preferred)
+ *
+ * Candidate ranks are non-decreasing within one key, so the on-disk order IS the
+ * display order. Ranks are engine-relative (like the `CKDT` rank byte and
+ * `PredictionResult.scores`), never probabilities.
+ *
+ * ## Bounds (untrusted pack input)
+ *
+ * Every length is validated before it is used to slice the buffer, counts are capped,
+ * and the reader refuses trailing bytes, bad UTF-8 replacement characters, duplicate
+ * or unsorted keys, and out-of-order ranks. A malformed table fails loudly at parse
+ * time instead of producing a silently wrong candidate list.
+ *
+ * ## Key normalization (build-time and lookup-time, fixed)
+ *  - lowercase ASCII `a-z`, `'` only (`v` spells `ü`; tones are dropped by the builder)
+ *  - no digits, spaces, hyphens; `xi'an` keeps the apostrophe
+ *  - `lookup`/`withPrefix` require an already-normalized query; anything else throws
+ *
+ * ## Ordinal ordering (deterministic)
+ *
+ * The file order is the lookup order. [Table.lookup] is a binary search over the
+ * parsed list; [Table.withPrefix] is a lower-bound binary search plus a forward scan,
+ * so typing `"ni"` finds `"ni"`, `"nian"`, `"niang"`… in one contiguous run.
+ */
+object CkpyPhraseTable {
+
+    /** "CKPY" little-endian. */
+    const val MAGIC = 0x59504B43
+
+    /** The only version this reader understands. */
+    const val VERSION = 1
+
+    /** Fixed header size in bytes. */
+    const val HEADER_SIZE = 48
+
+    /** UTF-8 bytes reserved for the language tag. */
+    const val LANGUAGE_BYTES = 4
+
+    /** Refuse to materialise a phrase table larger than this (untrusted pack input). */
+    private const val MAX_FILE_BYTES = 64L * 1024 * 1024
+
+    private const val MAX_KEY_COUNT = 1_000_000
+    private const val MAX_KEY_BYTES = 120
+    private const val MAX_CANDIDATES_PER_KEY = 512
+    private const val MAX_TEXT_BYTES = 64
+
+    private const val STREAM_CHUNK = 64 * 1024
+
+    private val KEY_PATTERN = Regex("^[a-z']+$")
+
+    /** One candidate display form with its preference rank (0 = most preferred). */
+    data class Candidate(val text: String, val rank: Int)
+
+    /** One pinyin key and its ranked candidates, in display order. */
+    data class Entry(val key: String, val candidates: List<Candidate>)
+
+    /**
+     * A parsed, immutable phrase table. Entries are in ascending [Entry.key] order;
+     * the [language] tag is informational (the caller's pack `code` wins, exactly as
+     * the `CKDT` header tag does).
+     */
+    class Table internal constructor(
+        val language: String,
+        val entries: List<Entry>,
+    ) {
+        /** Exact-key lookup; [key] must be normalized (`^[a-z']+$`). */
+        fun lookup(key: String): Entry? {
+            require(KEY_PATTERN.matches(key)) {
+                "pinyin key \"$key\" is not normalized (lowercase a-z and ' only)"
+            }
+            val index = entries.binarySearch { it.key.compareTo(key) }
+            return if (index >= 0) entries[index] else null
+        }
+
+        /**
+         * Every entry whose key starts with the normalized [prefix], in key order.
+         * An empty prefix returns an empty list (a keyboard with no input shows no
+         * candidates, and this keeps the call from scanning the whole table).
+         */
+        fun withPrefix(prefix: String): List<Entry> {
+            require(prefix.all { it in 'a'..'z' || it == '\'' }) {
+                "pinyin prefix \"$prefix\" is not normalized (lowercase a-z and ' only)"
+            }
+            if (prefix.isEmpty()) return emptyList()
+            var index = entries.binarySearch { it.key.compareTo(prefix) }
+            if (index < 0) index = -index - 1
+            val matches = ArrayList<Entry>()
+            while (index < entries.size && entries[index].key.startsWith(prefix)) {
+                matches.add(entries[index])
+                index++
+            }
+            return matches
+        }
+    }
+
+    /** Read a CKPY file from disk. */
+    fun read(file: File): Table {
+        require(file.length() <= MAX_FILE_BYTES) {
+            "CKPY file is ${file.length()} bytes, over the $MAX_FILE_BYTES-byte limit"
+        }
+        return file.inputStream().use { read(it) }
+    }
+
+    /** Read a CKPY table from [input], fully consuming it. */
+    fun read(input: InputStream): Table = read(readBounded(input))
+
+    /** Read a CKPY table from an in-memory byte array. */
+    fun read(bytes: ByteArray): Table {
+        require(bytes.size in HEADER_SIZE..MAX_FILE_BYTES.toInt()) {
+            "CKPY file too short: ${bytes.size} bytes (header is $HEADER_SIZE)"
+        }
+        val buffer = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+
+        val magic = buffer.int
+        require(magic == MAGIC) {
+            "not a CKPY phrase table: magic 0x%08X (expected 0x%08X)".format(magic, MAGIC)
+        }
+        val version = buffer.int
+        require(version == VERSION) {
+            "unsupported CKPY version $version (expected $VERSION)"
+        }
+
+        val languageBytes = ByteArray(LANGUAGE_BYTES)
+        buffer.get(languageBytes)
+        val language = String(languageBytes, Charsets.UTF_8).trimEnd('\u0000')
+
+        val keyCount = buffer.int
+        require(keyCount in 1..MAX_KEY_COUNT) {
+            "CKPY keyCount $keyCount out of range 1..$MAX_KEY_COUNT"
+        }
+
+        val dataOffset = buffer.int
+        require(dataOffset in HEADER_SIZE..bytes.size) {
+            "CKPY dataOffset $dataOffset out of range $HEADER_SIZE..${bytes.size}"
+        }
+        buffer.position(dataOffset)
+
+        val entries = ArrayList<Entry>(keyCount)
+        var previousKey: String? = null
+        for (i in 0 until keyCount) {
+            val keyLength = readLength(buffer, "key length")
+            require(keyLength in 1..MAX_KEY_BYTES) {
+                "CKPY key length $keyLength out of range 1..$MAX_KEY_BYTES"
+            }
+            val key = readUtf8(buffer, keyLength, "key")
+            require(KEY_PATTERN.matches(key)) {
+                "CKPY key \"$key\" is not normalized (lowercase a-z and ' only)"
+            }
+            require(previousKey == null || key > previousKey!!) {
+                "CKPY keys are not strictly ascending: \"$key\" after \"$previousKey\""
+            }
+            previousKey = key
+
+            val candidateCount = readLength(buffer, "candidate count")
+            require(candidateCount in 1..MAX_CANDIDATES_PER_KEY) {
+                "CKPY candidate count $candidateCount out of range 1..$MAX_CANDIDATES_PER_KEY"
+            }
+            val candidates = ArrayList<Candidate>(candidateCount)
+            var previousRank = -1
+            for (c in 0 until candidateCount) {
+                val textLength = readLength(buffer, "candidate length")
+                require(textLength in 1..MAX_TEXT_BYTES) {
+                    "CKPY candidate length $textLength out of range 1..$MAX_TEXT_BYTES"
+                }
+                val text = readUtf8(buffer, textLength, "candidate text")
+                require(text.isNotEmpty() && !text.contains('\uFFFD')) {
+                    "CKPY candidate for \"$key\" is not valid UTF-8 text"
+                }
+                val rank = buffer.get().toInt() and 0xFF
+                require(rank >= previousRank) {
+                    "CKPY candidates for \"$key\" are not rank-ordered: $rank after $previousRank"
+                }
+                previousRank = rank
+                candidates.add(Candidate(text, rank))
+            }
+            entries.add(Entry(key, candidates))
+        }
+
+        require(!buffer.hasRemaining()) {
+            "CKPY has ${buffer.remaining()} trailing bytes"
+        }
+        return Table(language, entries)
+    }
+
+    /** Read at most [MAX_FILE_BYTES] so a hostile stream cannot exhaust the heap. */
+    private fun readBounded(input: InputStream): ByteArray {
+        val out = ByteArrayOutputStream()
+        val chunk = ByteArray(STREAM_CHUNK)
+        var total = 0L
+        while (true) {
+            val read = input.read(chunk)
+            if (read <= 0) break
+            total += read
+            require(total <= MAX_FILE_BYTES) {
+                "CKPY stream exceeds the $MAX_FILE_BYTES-byte limit"
+            }
+            out.write(chunk, 0, read)
+        }
+        return out.toByteArray()
+    }
+
+    private fun readLength(buffer: ByteBuffer, what: String): Int {
+        require(buffer.remaining() >= 2) { "CKPY truncated while reading $what" }
+        return buffer.short.toInt() and 0xFFFF
+    }
+
+    private fun readUtf8(buffer: ByteBuffer, length: Int, what: String): String {
+        require(buffer.remaining() >= length) { "CKPY truncated while reading $what" }
+        val bytes = ByteArray(length)
+        buffer.get(bytes)
+        return String(bytes, Charsets.UTF_8)
+    }
+}

--- a/src/main/kotlin/tribixbite/cleverkeys/pinyin/PinyinComposingHook.kt
+++ b/src/main/kotlin/tribixbite/cleverkeys/pinyin/PinyinComposingHook.kt
@@ -1,0 +1,21 @@
+package tribixbite.cleverkeys.pinyin
+
+/**
+ * Late-bound seam between a pipeline that produces pinyin surfaces and the composing
+ * session. Implemented by [PinyinController]; consumed by `SuggestionHandler` so the
+ * swipe pipeline can hand the decoded spelling to the IME instead of auto-committing it.
+ *
+ * Kept as a separate interface so `SuggestionHandler` (a core class with no pinyin
+ * dependency) only ever sees this contract.
+ */
+interface PinyinComposingHook {
+
+    /**
+     * Feed the decoded swipe slate into the composing session.
+     *
+     * @return true when a composing session consumed the slate — the caller MUST NOT
+     *   auto-insert, rescore, or display the words as English suggestions. False when no
+     *   session is active; the caller's normal swipe flow runs untouched.
+     */
+    fun onSwipeDecoded(predictions: List<String>, scores: List<Int>): Boolean
+}

--- a/src/main/kotlin/tribixbite/cleverkeys/pinyin/PinyinController.kt
+++ b/src/main/kotlin/tribixbite/cleverkeys/pinyin/PinyinController.kt
@@ -1,0 +1,406 @@
+package tribixbite.cleverkeys.pinyin
+
+import android.content.Context
+import android.util.Log
+import android.view.KeyEvent
+import android.view.inputmethod.InputConnection
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import tribixbite.cleverkeys.BuildConfig
+import tribixbite.cleverkeys.SuggestionBar
+import tribixbite.cleverkeys.SuggestionMeta
+import tribixbite.cleverkeys.SuggestionOrigin
+import tribixbite.cleverkeys.langpack.LanguagePackManager
+
+/**
+ * IME glue for the pinyin composing mode (gh #177): decides when the active language is a
+ * pinyin pack, owns the [PinyinSession], drives the editor composing region, and feeds the
+ * suggestion bar. The pure session logic lives in [PinyinSession]; this class is the only
+ * part that touches Android.
+ *
+ * ## When the mode is active
+ *
+ * The active primary language's INSTALLED pack declares `"inputMethod": "pinyin"` and
+ * ships a parseable `phrases.bin`. [onStartInputView] evaluates this per field; the
+ * language is re-checked on the next key when it changes mid-field. A missing/corrupt
+ * table, a password/PIN field, or a non-pinyin pack leaves the controller inactive and the
+ * keyboard behaves exactly as before (Latin letters commit directly) — the
+ * fallback-to-Latin rule in `docs/specs/pinyin-ime.md` FR-11.
+ *
+ * ## Composing region vs committed fallback (spec open question Q1)
+ *
+ * The primary path publishes the preedit with [InputConnection.setComposingText], so
+ * editors underline the pinyin and one `commitText` replaces it with the chosen 汉字. If
+ * the editor refuses the first `setComposingText` (returns false), the controller flips to
+ * a committed-text fallback for that field: the same buffer is mirrored as real text, and
+ * updates/deletes use `commitText`/`deleteSurroundingText`, the pattern the English replace
+ * path already uses. Both paths are exercised by tests; the switch is per field.
+ *
+ * ## Privacy
+ *
+ * Never active in password/PIN fields (the caller passes the classification from
+ * `SuggestionBar.isPasswordField`). Nothing is learned: selections do not feed the n-gram
+ * model or `PredictionContextTracker`, matching the spec's Phase-1 isolation rule.
+ */
+class PinyinController(
+    private val languageProvider: () -> String?,
+    private val inputConnectionProvider: () -> InputConnection?,
+    private val suggestionBarProvider: () -> SuggestionBar?,
+    private val packManagerProvider: () -> LanguagePackManager?,
+    private val scope: CoroutineScope,
+    private val ioDispatcher: CoroutineDispatcher,
+) : PinyinComposingHook {
+
+    companion object {
+        private const val TAG = "PinyinController"
+
+        /**
+         * Production factory: main-thread mutations, IO table load. The process-lifetime
+         * scope is intentional — a field change must not cancel an in-flight parse, and the
+         * service owns the objects for its own lifetime.
+         */
+        fun create(
+            context: Context,
+            languageProvider: () -> String?,
+            inputConnectionProvider: () -> InputConnection?,
+            suggestionBarProvider: () -> SuggestionBar?,
+        ): PinyinController = PinyinController(
+            languageProvider = languageProvider,
+            inputConnectionProvider = inputConnectionProvider,
+            suggestionBarProvider = suggestionBarProvider,
+            packManagerProvider = { LanguagePackManager.getInstance(context) },
+            scope = CoroutineScope(SupervisorJob() + Dispatchers.Main.immediate),
+            ioDispatcher = Dispatchers.IO,
+        )
+    }
+
+    /** Language whose mode was last evaluated (null before the first evaluation). */
+    private var modeLanguage: String? = null
+
+    /** Whether the last evaluation wanted pinyin mode (before load success). */
+    private var modeWanted = false
+
+    /** Whether a table is loaded AND the mode is currently wanted. */
+    private var active = false
+
+    /** Last field's password classification, set by [onStartInputView]. */
+    private var passwordField = false
+
+    /** Whether the preedit is published through the composing region for this field. */
+    private var composingMode = true
+
+    private var loadedLanguage: String? = null
+    private var table: CkpyPhraseTable.Table? = null
+    private var session: PinyinSession? = null
+    private var loadJob: Job? = null
+
+    /** True while the composing session owns key input in the focused field. */
+    fun isActive(): Boolean = active
+
+    /**
+     * Field-start hook. Resets the session, re-evaluates the language's pack, and keeps
+     * the composing region for the new field.
+     */
+    fun onStartInputView(isPasswordField: Boolean) {
+        passwordField = isPasswordField
+        composingMode = true
+        resetSession(clearBar = true)
+        evaluateMode(force = true)
+    }
+
+    /**
+     * Field-end hook: cancel any composing run best-effort (the connection may already be
+     * gone), clear the bar, and deactivate until the next field.
+     */
+    fun onFinishInputView() {
+        val s = session
+        val conn = inputConnectionProvider()
+        if (s != null && !s.isEmpty && conn != null) {
+            runCatching {
+                if (composingMode) conn.setComposingText("", 1) else replaceCommittedPinyin(conn, s)
+            }
+        }
+        active = false
+        resetSession(clearBar = true)
+    }
+
+    /**
+     * A letter/space/other character was typed. Returns true when the composing session
+     * consumed it; false lets `KeyEventHandler.sendText` run the normal path.
+     */
+    fun handleTypedText(text: String): Boolean {
+        syncMode()
+        if (!isActive()) return false
+        val s = session ?: return false
+        val conn = inputConnectionProvider() ?: return false
+
+        if (text == " ") {
+            if (s.isEmpty) return false
+            commitTop(conn, s)
+            return true
+        }
+
+        val normalized = if (text.length == 1) PinyinSession.normalizeLetter(text[0]) else null
+        if (normalized != null) {
+            preeditMatchesEditor(conn, s)
+            if (!s.appendLetter(text[0])) return false
+            updatePreedit(conn, s, appended = normalized.toString())
+            updateCandidates()
+            return true
+        }
+
+        // Punctuation, digits, a macro string… End the composing run and keep whatever the
+        // user typed as plain text, then let the normal path commit this character.
+        flushRaw(conn, s)
+        return false
+    }
+
+    /**
+     * Backspace: edit the buffer while one exists. Returns false on an empty buffer so the
+     * normal backspace path (deleting committed text) runs.
+     */
+    fun handleBackspace(): Boolean {
+        syncMode()
+        if (!isActive()) return false
+        val s = session ?: return false
+        if (s.isEmpty) return false
+        val conn = inputConnectionProvider() ?: return false
+
+        preeditMatchesEditor(conn, s)
+        if (s.isEmpty) return false
+
+        val removed = s.composingText.last()
+        s.backspace()
+        if (composingMode) {
+            if (!conn.setComposingText(s.composingText, 1)) composingMode = false
+        }
+        if (!composingMode) {
+            val before = conn.getTextBeforeCursor(1, 0)?.toString()
+            if (before == removed.toString()) conn.deleteSurroundingText(1, 0)
+        }
+        if (s.isEmpty) clearCandidates() else updateCandidates()
+        return true
+    }
+
+    /**
+     * Enter commits the top candidate and returns false so the editor action still fires;
+     * Escape cancels the composing run and is consumed. Other key events are left alone
+     * (the next typed key verifies whether the composing run is still aligned).
+     */
+    fun handleKeyevent(keyCode: Int): Boolean {
+        syncMode()
+        if (!isActive()) return false
+        val s = session ?: return false
+        if (s.isEmpty) return false
+        val conn = inputConnectionProvider() ?: return false
+        return when (keyCode) {
+            KeyEvent.KEYCODE_ENTER, KeyEvent.KEYCODE_NUMPAD_ENTER -> {
+                commitTop(conn, s)
+                false
+            }
+            KeyEvent.KEYCODE_ESCAPE -> {
+                cancel(conn, s)
+                true
+            }
+            else -> false
+        }
+    }
+
+    /**
+     * A candidate tap from the suggestion bar. Only words the session itself offered are
+     * consumed, so a stale English suggestion can never be swallowed as 汉字.
+     */
+    fun onCandidateSelected(word: String): Boolean {
+        syncMode()
+        if (!isActive()) return false
+        val s = session ?: return false
+        if (s.isEmpty) return false
+        if (s.candidates().none { it.text == word }) return false
+        val conn = inputConnectionProvider() ?: return false
+        commitText(conn, s, word)
+        return true
+    }
+
+    /** Swipe decoded to a pinyin spelling: buffer it, show candidates, never auto-commit. */
+    override fun onSwipeDecoded(predictions: List<String>, scores: List<Int>): Boolean {
+        syncMode()
+        if (!isActive()) return false
+        val s = session ?: return true
+        val conn = inputConnectionProvider() ?: return true
+
+        preeditMatchesEditor(conn, s)
+        val appended = s.appendSurface(predictions.firstOrNull().orEmpty())
+        if (appended.isNotEmpty()) {
+            if (composingMode) {
+                if (!conn.setComposingText(s.composingText, 1) && s.length == appended.length) {
+                    composingMode = false
+                    conn.commitText(s.composingText, 1)
+                }
+            } else {
+                conn.commitText(appended, 1)
+            }
+        }
+        updateCandidates()
+        return true
+    }
+
+    // -------------------------------------------------------------------- mode + loading
+
+    /** Re-evaluate the mode only when the active language changed since the last check. */
+    private fun syncMode() {
+        if (languageProvider() != modeLanguage) evaluateMode(force = false)
+    }
+
+    private fun evaluateMode(force: Boolean) {
+        val language = languageProvider()
+        if (!force && language == modeLanguage) return
+        modeLanguage = language
+
+        val manifest = language?.let { packManagerProvider()?.getInstalledPack(it) }
+        modeWanted = !passwordField &&
+            manifest?.inputMethod == LanguagePackManager.INPUT_METHOD_PINYIN
+
+        if (!modeWanted) {
+            loadJob?.cancel()
+            table = null
+            loadedLanguage = null
+            session = null
+            active = false
+            return
+        }
+
+        val loaded = table
+        if (loaded != null && loadedLanguage == language) {
+            if (session == null) session = PinyinSession(loaded)
+            active = true
+            return
+        }
+
+        active = false
+        loadAsync(language!!)
+    }
+
+    private fun loadAsync(language: String) {
+        loadJob?.cancel()
+        loadJob = scope.launch {
+            val loaded = withContext(ioDispatcher) {
+                val file = packManagerProvider()?.getPhrasesPath(language)
+                    ?: return@withContext null
+                runCatching { CkpyPhraseTable.read(file) }.getOrNull()
+            }
+            if (loaded == null) {
+                // Pack declared pinyin but the table is unusable: stay inactive, commit Latin.
+                if (BuildConfig.ENABLE_VERBOSE_LOGGING) {
+                    Log.w(TAG, "phrases.bin for \"$language\" could not be loaded; pinyin mode off")
+                }
+                return@launch
+            }
+            if (languageProvider() != language) return@launch
+            table = loaded
+            loadedLanguage = language
+            session = PinyinSession(loaded)
+            active = modeWanted
+        }
+    }
+
+    // ----------------------------------------------------------------- preedit + candidates
+
+    /**
+     * Verify that the editor still shows exactly our composing run (or that we are in the
+     * committed fallback, which is verified at its deletion sites). On a mismatch the run
+     * is abandoned and the caller starts cleanly — the repo's "verify at use" pattern.
+     */
+    private fun preeditMatchesEditor(conn: InputConnection, s: PinyinSession): Boolean {
+        if (s.isEmpty || !composingMode) return true
+        val before = conn.getTextBeforeCursor(s.length, 0)?.toString()
+        if (before == s.composingText) return true
+        s.clear()
+        clearCandidates()
+        return false
+    }
+
+    private fun updatePreedit(conn: InputConnection, s: PinyinSession, appended: String) {
+        if (composingMode) {
+            if (!conn.setComposingText(s.composingText, 1)) {
+                // The editor refused the composing region. Mirror the fresh run as real
+                // text; later updates commit their characters and deletions remove them.
+                if (s.length == appended.length) {
+                    composingMode = false
+                    conn.commitText(s.composingText, 1)
+                }
+            }
+        } else {
+            conn.commitText(appended, 1)
+        }
+    }
+
+    private fun commitTop(conn: InputConnection, s: PinyinSession) {
+        commitText(conn, s, s.topCandidate() ?: s.composingText)
+    }
+
+    private fun commitText(conn: InputConnection, s: PinyinSession, text: String) {
+        if (text.isEmpty()) return
+        if (!composingMode) replaceCommittedPinyin(conn, s)
+        conn.commitText(text, 1)
+        s.clear()
+        clearCandidates()
+    }
+
+    /** Keep the typed pinyin as plain text and end the composing run. */
+    private fun flushRaw(conn: InputConnection, s: PinyinSession) {
+        if (s.isEmpty) return
+        if (composingMode) conn.finishComposingText()
+        s.clear()
+        clearCandidates()
+    }
+
+    /** Drop the composing run without committing the candidate. */
+    private fun cancel(conn: InputConnection, s: PinyinSession) {
+        if (s.isEmpty) return
+        if (composingMode) conn.setComposingText("", 1) else replaceCommittedPinyin(conn, s)
+        s.clear()
+        clearCandidates()
+    }
+
+    /** In the fallback path the preedit is real text: delete it before replacing. */
+    private fun replaceCommittedPinyin(conn: InputConnection, s: PinyinSession) {
+        val text = s.composingText
+        if (text.isEmpty()) return
+        if (conn.getTextBeforeCursor(text.length, 0)?.toString() == text) {
+            conn.deleteSurroundingText(text.length, 0)
+        }
+    }
+
+    private fun resetSession(clearBar: Boolean) {
+        session?.clear()
+        if (clearBar) clearCandidates()
+    }
+
+    private fun updateCandidates() {
+        val s = session ?: return
+        if (s.isEmpty) {
+            clearCandidates()
+            return
+        }
+        val candidates = s.candidates()
+        if (candidates.isEmpty()) {
+            clearCandidates()
+            return
+        }
+        val bar = suggestionBarProvider() ?: return
+        bar.setSuggestionsWithScores(
+            candidates.map { it.text },
+            candidates.map { it.score },
+            candidates.map { SuggestionMeta(SuggestionOrigin.PINYIN) },
+        )
+    }
+
+    private fun clearCandidates() {
+        suggestionBarProvider()?.clearSuggestions()
+    }
+}

--- a/src/main/kotlin/tribixbite/cleverkeys/pinyin/PinyinSession.kt
+++ b/src/main/kotlin/tribixbite/cleverkeys/pinyin/PinyinSession.kt
@@ -1,0 +1,221 @@
+package tribixbite.cleverkeys.pinyin
+
+/**
+ * Pure state machine for ONE pinyin composing run: the typed/swiped key buffer and the
+ * ranked candidate list assembled from a [CkpyPhraseTable.Table].
+ *
+ * This class owns no Android types on purpose — the IME glue ([PinyinController]) owns the
+ * `InputConnection`, the suggestion bar, and the async table load; every decision about what
+ * the buffer contains and what the candidates are is testable in `runPureTests`.
+ *
+ * ## Candidate assembly (deterministic)
+ *
+ *  1. exact key match (`nihao`) — its candidates in rank order;
+ *  2. then every longer key the buffer is a prefix of (`ni` → `nian`, `niang`, …), in key
+ *     order, each entry's candidates in rank order, de-duplicated by text;
+ *  3. if neither matched, greedy longest-match segmentation (`woaini` → `wo` + `ai` + `ni`)
+ *     joins each segment's top candidate, plus bounded second-candidate variants.
+ *
+ * Rule 3 is the Phase-3 segmentation cut agreed in `docs/specs/pinyin-ime.md`: greedy, not a
+ * lattice. It makes unbounded input useful without pretending to be a full decoder.
+ *
+ * ## Input normalization (matches the pack-side rules)
+ *  - letters are lowercased; `ü`/`Ü` become `v` (女 = `nv`)
+ *  - `'`, `’`, `‘`, `` ` `` become `'` (so `xi'an` and `xian` stay distinct)
+ *  - anything else is not pinyin and is refused by [appendLetter]
+ */
+class PinyinSession(private val table: CkpyPhraseTable.Table) {
+
+    companion object {
+        /** Most candidates the bar is offered per update. */
+        const val MAX_CANDIDATES = 8
+
+        /** Hard cap on one composing run; longer input cannot resolve to one key anyway. */
+        const val MAX_BUFFER_LENGTH = 48
+
+        /**
+         * Stop scanning extension keys after this many de-duplicated candidates, so a
+         * one-letter buffer with a huge prefix fan-out cannot walk a 500k-entry table.
+         */
+        private const val EXTENSION_SCAN_LIMIT = MAX_CANDIDATES * 3
+
+        /** [CkpyPhraseTable] rank (0 = best) → display score; engine-relative, never a probability. */
+        internal fun scoreForRank(rank: Int): Int = 1000 - rank.coerceIn(0, 255) * 3
+
+        /** Returns the normalized form of [letter], or null when it is not pinyin input. */
+        internal fun normalizeLetter(letter: Char): Char? = when (letter) {
+            in 'a'..'z' -> letter
+            in 'A'..'Z' -> letter.lowercaseChar()
+            '\'', '\u2019', '\u2018', '`' -> '\''
+            '\u00fc', '\u00dc' -> 'v' // ü / Ü
+            else -> null
+        }
+    }
+
+    /** One display candidate with its engine-relative score (order is the contract). */
+    data class Candidate(val text: String, val score: Int)
+
+    private val buffer = StringBuilder()
+
+    /** The preedit shown (or hidden) by the composing region. */
+    val composingText: String get() = buffer.toString()
+
+    /** Current buffer length in characters. */
+    val length: Int get() = buffer.length
+
+    /** True when no input has been buffered yet. */
+    val isEmpty: Boolean get() = buffer.isEmpty()
+
+    /** True when the buffer is at [MAX_BUFFER_LENGTH] and [appendLetter] would refuse. */
+    val isFull: Boolean get() = buffer.length >= MAX_BUFFER_LENGTH
+
+    /**
+     * Append one keyboard character.
+     *
+     * @return true when it became part of the buffer (the caller must then refresh the
+     *   preedit/candidates); false for non-pinyin characters and a full buffer, in which
+     *   case the caller should let the normal key path handle it.
+     */
+    fun appendLetter(letter: Char): Boolean {
+        val normalized = normalizeLetter(letter) ?: return false
+        if (isFull) return false
+        buffer.append(normalized)
+        return true
+    }
+
+    /**
+     * Append a whole surface (a swipe-decoded pinyin spelling), keeping only the characters
+     * pinyin accepts.
+     *
+     * @return the exact normalized text that was appended; empty when nothing usable was
+     *   left or the buffer was already full.
+     */
+    fun appendSurface(surface: String): String {
+        val appended = StringBuilder()
+        for (char in surface) {
+            val normalized = normalizeLetter(char) ?: continue
+            if (buffer.length >= MAX_BUFFER_LENGTH) break
+            buffer.append(normalized)
+            appended.append(normalized)
+        }
+        return appended.toString()
+    }
+
+    /**
+     * Delete the last buffered character.
+     *
+     * @return true when a character was removed; false on an empty buffer (the caller
+     *   should then let the normal backspace path run).
+     */
+    fun backspace(): Boolean {
+        if (buffer.isEmpty()) return false
+        buffer.setLength(buffer.length - 1)
+        return true
+    }
+
+    /** Forget the whole composing run. */
+    fun clear() {
+        buffer.setLength(0)
+    }
+
+    /**
+     * Ranked candidates for the current buffer; empty when the buffer is empty or nothing
+     * can be resolved yet.
+     */
+    fun candidates(limit: Int = MAX_CANDIDATES): List<Candidate> {
+        if (buffer.isEmpty() || limit <= 0) return emptyList()
+        val key = buffer.toString()
+        val ordered = LinkedHashMap<String, Int>()
+
+        fun offer(text: String, rank: Int) {
+            if (text.isNotEmpty()) ordered.putIfAbsent(text, scoreForRank(rank))
+        }
+
+        // 1. exact key — always first, in the table's rank order.
+        table.lookup(key)?.candidates?.forEach { offer(it.text, it.rank) }
+
+        // 2. completion extensions (keys the buffer is a prefix of), bounded.
+        for (entry in table.withPrefix(key)) {
+            if (entry.key == key) continue
+            for (candidate in entry.candidates) {
+                offer(candidate.text, candidate.rank)
+                if (ordered.size >= EXTENSION_SCAN_LIMIT) break
+            }
+            if (ordered.size >= EXTENSION_SCAN_LIMIT) break
+        }
+
+        // 3. greedy segmentation fallback for input no single key covers.
+        if (ordered.isEmpty()) {
+            for ((text, score) in segmentationCandidates(key, limit)) {
+                ordered.putIfAbsent(text, score)
+            }
+        }
+
+        return ordered.entries.take(limit).map { Candidate(it.key, it.value) }
+    }
+
+    /** Best candidate for the current buffer, or null. */
+    fun topCandidate(): String? = candidates(limit = 1).firstOrNull()?.text
+
+    /**
+     * Greedy longest-match segmentation of [key] into known phrase keys, then a join of the
+     * segments' top candidates. Bounded second-candidate variants follow (last segments
+     * first, because trailing syllables carry the most ambiguity in practice).
+     */
+    private fun segmentationCandidates(key: String, limit: Int): List<Pair<String, Int>> {
+        val segments = ArrayList<CkpyPhraseTable.Entry>()
+        var position = 0
+        while (position < key.length) {
+            val entry = longestKeyAt(key, position) ?: return emptyList()
+            segments.add(entry)
+            position += entry.key.length
+        }
+        if (segments.isEmpty()) return emptyList()
+
+        fun top(entry: CkpyPhraseTable.Entry, index: Int = 0): CkpyPhraseTable.Candidate =
+            entry.candidates.getOrElse(index) { entry.candidates.first() }
+
+        fun join(pick: (Int, CkpyPhraseTable.Entry) -> String): String =
+            segments.mapIndexed { index, entry -> pick(index, entry) }.joinToString("")
+
+        val results = LinkedHashMap<String, Int>()
+        val baseText = join { _, entry -> top(entry).text }
+        results[baseText] = variantScore(segments, variantIndex = -1)
+
+        // Second-candidate variants, most significant (trailing) segment first.
+        for (index in segments.indices.reversed()) {
+            if (results.size >= limit) break
+            if (segments[index].candidates.size < 2) continue
+            val text = join { i, entry -> if (i == index) top(entry, 1).text else top(entry).text }
+            results.putIfAbsent(text, variantScore(segments, variantIndex = index))
+        }
+        return results.entries.map { it.key to it.value }
+    }
+
+    /** The longest known key that starts at [position], or null when none does. */
+    private fun longestKeyAt(input: String, position: Int): CkpyPhraseTable.Entry? {
+        val remaining = input.length - position
+        val maxLength = minOf(remaining, MAX_BUFFER_LENGTH)
+        for (length in maxLength downTo 1) {
+            table.lookup(input.substring(position, position + length))?.let { return it }
+        }
+        return null
+    }
+
+    /**
+     * Combined score of a segmentation variant: the WORST rank among its picks (0 for the
+     * base variant, `variantIndex`'s runner-up candidate for a variant, everything else
+     * top). A join is only as good as its least certain syllable.
+     */
+    private fun variantScore(segments: List<CkpyPhraseTable.Entry>, variantIndex: Int): Int {
+        var worstRank = 0
+        for (index in segments.indices) {
+            val pick = if (index == variantIndex) 1 else 0
+            val candidate = segments[index].candidates.getOrElse(pick) {
+                segments[index].candidates.first()
+            }
+            worstRank = maxOf(worstRank, candidate.rank)
+        }
+        return scoreForRank(worstRank)
+    }
+}

--- a/src/main/kotlin/tribixbite/cleverkeys/wiring/KeyEventReceiverBridge.kt
+++ b/src/main/kotlin/tribixbite/cleverkeys/wiring/KeyEventReceiverBridge.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.os.Handler
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputConnection
+import tribixbite.cleverkeys.pinyin.PinyinController
 
 /**
  * Bridge between KeyEventHandler and KeyboardReceiver.
@@ -33,6 +34,12 @@ class KeyEventReceiverBridge(
     private var contextTracker: PredictionContextTracker? = null
 
     /**
+     * gh #177: pinyin composing session. Late-bound like the receiver — the service builds
+     * the controller after the graph, and every pinyin hook below is a no-op until then.
+     */
+    private var pinyinController: PinyinController? = null
+
+    /**
      * Set the KeyboardReceiver instance.
      * Must be called after KeyboardReceiver is created.
      *
@@ -40,6 +47,11 @@ class KeyEventReceiverBridge(
      */
     fun setReceiver(receiver: KeyboardReceiver) {
         this.receiver = receiver
+    }
+
+    /** gh #177: hand over the pinyin composing controller once it exists. */
+    fun setPinyinController(controller: PinyinController?) {
+        this.pinyinController = controller
     }
 
     /**
@@ -94,6 +106,24 @@ class KeyEventReceiverBridge(
     override fun handle_delete_last_word() {
         receiver?.handle_delete_last_word()
     }
+
+    // gh #177: pinyin composing hooks. Modal panes (clipboard tag/edit/search, emoji, GIF)
+    // own the keyboard while open, so typing there must never be buffered as pinyin; the
+    // text hook defers to them first. Backspace/keyevent are reached only after
+    // KeyEventHandler has already routed the modal branches, so they need no gate.
+    override fun pinyinHandleText(text: String): Boolean {
+        if (isClipboardTagMode() || isClipboardEditMode() || isClipboardSearchMode() ||
+            isEmojiPaneOpen() || isGifPaneOpen()) {
+            return false
+        }
+        return pinyinController?.handleTypedText(text) == true
+    }
+
+    override fun pinyinHandleBackspace(): Boolean =
+        pinyinController?.handleBackspace() == true
+
+    override fun pinyinHandleKeyevent(keyCode: Int): Boolean =
+        pinyinController?.handleKeyevent(keyCode) == true
 
     override fun isClipboardSearchMode(): Boolean {
         return receiver?.isClipboardSearchMode() ?: false

--- a/src/main/kotlin/tribixbite/cleverkeys/wiring/SuggestionBridge.kt
+++ b/src/main/kotlin/tribixbite/cleverkeys/wiring/SuggestionBridge.kt
@@ -87,6 +87,10 @@ class SuggestionBridge(
         // Trigger haptic feedback for prediction tap
         keyboardView.triggerHaptic(HapticEvent.PREDICTION_TAP)
 
+        // gh #177: a pinyin composing candidate commits through the session (and only a
+        // word the session offered is consumed). No ML capture/autocorrect/replace path.
+        if (keyboard2.pinyinController()?.onCandidateSelected(word) == true) return
+
         // Store ML data if this was a swipe prediction selection
         val isSwipeAutoInsert = contextTracker.wasLastInputSwipe()
         val currentSwipeData = inputCoordinator.getCurrentSwipeData()

--- a/src/test/kotlin/tribixbite/cleverkeys/SuggestionPinyinHookTest.kt
+++ b/src/test/kotlin/tribixbite/cleverkeys/SuggestionPinyinHookTest.kt
@@ -1,0 +1,102 @@
+package tribixbite.cleverkeys
+
+import android.content.res.Resources
+import android.view.inputmethod.InputConnection
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.unmockkAll
+import io.mockk.verify
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.objenesis.ObjenesisStd
+import tribixbite.cleverkeys.pinyin.PinyinComposingHook
+
+/**
+ * gh #177: the swipe pipeline's pinyin seam. Pins that a consuming
+ * [PinyinComposingHook] short-circuits `handleSwipePredictionResults` BEFORE the
+ * password and empty-slate guards (an empty decode must not clear the composing
+ * candidates) and before any English step (no bar render, no auto-commit). A
+ * non-consuming hook leaves the legacy flow untouched.
+ *
+ * The handler is built with Objenesis (the repo pattern for exercising one method on
+ * a 2,600-line class) — `handleSwipePredictionResults`'s hook branch reads only the
+ * bar and the hook itself, so no constructor side effects are involved.
+ */
+class SuggestionPinyinHookTest {
+
+    private val objenesis = ObjenesisStd()
+
+    private lateinit var handler: SuggestionHandler
+    private lateinit var bar: SuggestionBar
+    private lateinit var coordinator: InputCoordinator
+    private lateinit var ic: InputConnection
+    private lateinit var resources: Resources
+
+    @Before
+    fun setup() {
+        handler = objenesis.newInstance(SuggestionHandler::class.java)
+        bar = mockk(relaxed = true)
+        handler.setSuggestionBar(bar)
+        coordinator = mockk(relaxed = true)
+        ic = mockk(relaxed = true)
+        resources = mockk(relaxed = true)
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+    }
+
+    private fun hookThatConsumes(consumes: Boolean): PinyinComposingHook =
+        mockk<PinyinComposingHook>().also {
+            every { it.onSwipeDecoded(any(), any()) } returns consumes
+        }
+
+    private fun swipe(predictions: List<String>?, scores: List<Int>?) {
+        handler.handleSwipePredictionResults(
+            predictions, scores, ic, null, resources,
+            shiftActive = false, shiftLocked = false, inputCoordinator = coordinator,
+        )
+    }
+
+    @Test
+    fun aConsumingHookSuppressesTheEnglishSwipePipeline() {
+        val hook = hookThatConsumes(true)
+        handler.setPinyinHook(hook)
+
+        swipe(listOf("nihao"), listOf(900))
+
+        verify { hook.onSwipeDecoded(listOf("nihao"), listOf(900)) }
+        verify(exactly = 0) { bar.setSuggestionsWithScores(any(), any(), any()) }
+        verify(exactly = 0) { ic.commitText(any(), any()) }
+    }
+
+    @Test
+    fun anEmptyDecodeStillReachesTheHookAndKeepsTheCandidates() {
+        val hook = hookThatConsumes(true)
+        handler.setPinyinHook(hook)
+
+        swipe(null, null)
+
+        verify { hook.onSwipeDecoded(emptyList(), emptyList()) }
+        verify(exactly = 0) { bar.clearSuggestions() }
+    }
+
+    @Test
+    fun aNonConsumingHookLeavesTheLegacyFlowAlone() {
+        val hook = hookThatConsumes(false)
+        handler.setPinyinHook(hook)
+
+        swipe(null, null)
+
+        verify { hook.onSwipeDecoded(emptyList(), emptyList()) }
+        verify { bar.clearSuggestions() }
+    }
+
+    @Test
+    fun withoutAHookTheSwipePipelineIsUnchanged() {
+        swipe(null, null)
+        verify { bar.clearSuggestions() }
+    }
+}

--- a/src/test/kotlin/tribixbite/cleverkeys/langpack/LanguagePackImportTest.kt
+++ b/src/test/kotlin/tribixbite/cleverkeys/langpack/LanguagePackImportTest.kt
@@ -75,6 +75,12 @@ class LanguagePackImportTest {
         0x02, 0x00, 0x00, 0x00, // version 2
     )
 
+    /** V1 `CKPY` magic + version, little-endian, as `validatePhraseTable` decodes it. */
+    private val ckpyV1Header = byteArrayOf(
+        0x43, 0x4B, 0x50, 0x59, // "CKPY"
+        0x01, 0x00, 0x00, 0x00, // version 1
+    )
+
     @Before
     fun setup() {
         mockkStatic(Log::class)
@@ -120,13 +126,17 @@ class LanguagePackImportTest {
         wordCount: Int = 0,
         hasPrefixBoost: Boolean = false,
         model: ByteArray? = null,
+        inputMethod: String? = null,
     ): String {
         val modelField = model?.let {
             ""","model":{"file":"model.onnx","sha256":"${sha256(it)}"}"""
         } ?: ""
+        val inputMethodField = inputMethod?.let {
+            ""","inputMethod":"$it""""
+        } ?: ""
         return """
             {"code":"$code","name":"$name","version":$version,"author":"$author",
-             "wordCount":$wordCount,"hasPrefixBoost":$hasPrefixBoost$modelField}
+             "wordCount":$wordCount,"hasPrefixBoost":$hasPrefixBoost$modelField$inputMethodField}
         """.trimIndent()
     }
 
@@ -142,6 +152,19 @@ class LanguagePackImportTest {
         val out = ByteArray(size)
         ckdtV2Header.copyInto(out)
         for (i in ckdtV2Header.size until size) out[i] = (i % 251).toByte()
+        return out
+    }
+
+    /**
+     * A V1-valid `CKPY` phrase table body of [size] bytes: real header, deterministic filler.
+     * The importer validates the fixed 8-byte magic+version header, exactly like CKDT; the
+     * full structural parse belongs to `CkpyPhraseTable` (see `CkpyPhraseTableTest`).
+     */
+    private fun phraseTableBytes(size: Int = 64): ByteArray {
+        require(size >= ckpyV1Header.size)
+        val out = ByteArray(size)
+        ckpyV1Header.copyInto(out)
+        for (i in ckpyV1Header.size until size) out[i] = (i % 241).toByte()
         return out
     }
 
@@ -305,6 +328,8 @@ class LanguagePackImportTest {
         assertThat(manager.getContractionsPath("ms")).isNull()
         assertThat(manager.getPrefixBoostPath("ms")).isNull()
         assertThat(manager.getModelPath("ms")).isNull()
+        assertWithMessage("a legacy pack has no phrase table and no inputMethod")
+            .that(manager.getPhrasesPath("ms")).isNull()
         assertThat(manager.isInstalled("ms")).isTrue()
     }
 
@@ -421,6 +446,101 @@ class LanguagePackImportTest {
             "…and the load side refuses it anyway. The importer's hash check is an integrity " +
                 "check on the download; the app's pin is what keeps ORT off user-supplied bytes"
         ).that(CtcPackModel.verifiedPackModel(filesDir, "ru")).isNull()
+    }
+
+    // ------------------------------------------- composing IME packs (gh #177, pinyin)
+
+    /**
+     * A pinyin composing pack: `"inputMethod": "pinyin"` + a V1 `CKPY` `phrases.bin`. The
+     * import carries the phrase table to disk and the installed manifest reports the mode,
+     * while the CKDT dictionary still installs (the swipe path decodes pinyin spellings
+     * over it). Format spec: `docs/specs/pinyin-ime.md`.
+     */
+    @Test
+    fun aPinyinPackCarriesItsInputMethodAndPhraseTable() {
+        val phrases = phraseTableBytes()
+        val zip = validPack(
+            "zh", "中文（拼音）", wordCount = 1234,
+            manifest = manifestJson("zh", "中文（拼音）", wordCount = 1234, inputMethod = "pinyin"),
+            extras = listOf("phrases.bin" to phrases),
+        )
+
+        assertThat(import(zip)).isEqualTo(
+            ImportResult.Success(
+                LanguagePackManifest(
+                    "zh", "中文（拼音）", 1, "", 1234, false,
+                    inputMethod = "pinyin",
+                )
+            )
+        )
+
+        assertWithMessage("the phrase table must land beside the dictionary")
+            .that(manager.getPhrasesPath("zh")).isNotNull()
+        assertThat(manager.getPhrasesPath("zh")!!.readBytes()).isEqualTo(phrases)
+        assertThat(manager.getDictionaryPath("zh")).isNotNull()
+        assertWithMessage("the installed manifest must remember the mode for runtime selection")
+            .that(manager.getInstalledPacks().single().inputMethod).isEqualTo("pinyin")
+    }
+
+    @Test
+    fun aPinyinPackWithoutAPhraseTableIsRejected() {
+        val zip = validPack(
+            "zh", "Chinese",
+            manifest = manifestJson("zh", "Chinese", inputMethod = "pinyin"),
+        )
+        assertThat(import(zip)).isEqualTo(
+            ImportResult.Error("Missing phrases.bin for inputMethod \"pinyin\"")
+        )
+        assertWithMessage("a rejected pack must install nothing")
+            .that(File(filesDir, "langpacks").listFiles()?.toList().orEmpty()).isEmpty()
+    }
+
+    @Test
+    fun aPinyinPackWithAnInvalidPhraseTableIsRejected() {
+        val wrongMagic = phraseTableBytes().also { it[0] = 'X'.code.toByte() }
+        assertThat(
+            import(validPack(
+                "zh", "Chinese",
+                manifest = manifestJson("zh", "Chinese", inputMethod = "pinyin"),
+                extras = listOf("phrases.bin" to wrongMagic),
+            ))
+        ).isEqualTo(ImportResult.Error("Invalid phrases.bin format"))
+
+        val wrongVersion = phraseTableBytes().also { it[4] = 2 }
+        assertThat(
+            import(validPack(
+                "zh", "Chinese",
+                manifest = manifestJson("zh", "Chinese", inputMethod = "pinyin"),
+                extras = listOf("phrases.bin" to wrongVersion),
+            ))
+        ).isEqualTo(ImportResult.Error("Invalid phrases.bin format"))
+    }
+
+    /**
+     * Nothing reads a phrase table without the mode that consumes it, so silently dropping
+     * one would turn a manifest typo into a broken keyboard. Refused, with a reason.
+     */
+    @Test
+    fun aPhraseTableWithoutThePinyinInputMethodIsRejected() {
+        val zip = validPack(
+            "zh", "Chinese",
+            extras = listOf("phrases.bin" to phraseTableBytes()),
+        )
+        assertThat(import(zip)).isEqualTo(
+            ImportResult.Error("phrases.bin requires inputMethod \"pinyin\"")
+        )
+    }
+
+    @Test
+    fun anUnknownInputMethodIsRejectedRatherThanDegradingToWordfreq() {
+        val zip = validPack(
+            "zh", "Chinese",
+            manifest = manifestJson("zh", "Chinese", inputMethod = "bopomofo"),
+        )
+        assertThat(import(zip)).isEqualTo(
+            ImportResult.Error("Unsupported inputMethod \"bopomofo\"")
+        )
+        assertThat(manager.getInstalledPacks()).isEmpty()
     }
 
     // ------------------------------------------------------------- rejection surface

--- a/src/test/kotlin/tribixbite/cleverkeys/langpack/LanguagePackImportTest.kt
+++ b/src/test/kotlin/tribixbite/cleverkeys/langpack/LanguagePackImportTest.kt
@@ -543,6 +543,20 @@ class LanguagePackImportTest {
         assertThat(manager.getInstalledPacks()).isEmpty()
     }
 
+    @Test
+    fun anInstalledPacksInputMethodIsReadableByCode() {
+        import(validPack(
+            "zh", "中文（拼音）",
+            manifest = manifestJson("zh", "中文（拼音）", inputMethod = "pinyin"),
+            extras = listOf("phrases.bin" to phraseTableBytes()),
+        ))
+
+        assertWithMessage("the composing controller reads the mode through getInstalledPack")
+            .that(manager.getInstalledPack("zh")?.inputMethod).isEqualTo("pinyin")
+        assertWithMessage("a language with no installed pack reads back null, not a crash")
+            .that(manager.getInstalledPack("fr")).isNull()
+    }
+
     // ------------------------------------------------------------- rejection surface
 
     @Test

--- a/src/test/kotlin/tribixbite/cleverkeys/pinyin/CkpyPhraseTableTest.kt
+++ b/src/test/kotlin/tribixbite/cleverkeys/pinyin/CkpyPhraseTableTest.kt
@@ -1,0 +1,273 @@
+package tribixbite.cleverkeys.pinyin
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import java.io.ByteArrayOutputStream
+import java.nio.file.Files
+import org.junit.Test
+
+/**
+ * Pins the `CKPY` v1 phrase-table layout byte-for-byte: the fixtures below are assembled
+ * from raw little-endian fields (never through the production reader), so a change to the
+ * magic, the header offsets, the record framing, or the ordering rules fails here before it
+ * can ship in a pack that other tools build against.
+ *
+ * Layout source of truth: [CkpyPhraseTable] KDoc + `docs/specs/pinyin-ime.md`.
+ */
+class CkpyPhraseTableTest {
+
+    // ------------------------------------------------------------------ raw fixture builder
+
+    private data class FixtureEntry(val key: String, val candidates: List<Pair<String, Int>>)
+
+    private fun u16(value: Int) = byteArrayOf(
+        (value and 0xFF).toByte(),
+        ((value ushr 8) and 0xFF).toByte(),
+    )
+
+    private fun u32(value: Int) = byteArrayOf(
+        (value and 0xFF).toByte(),
+        ((value ushr 8) and 0xFF).toByte(),
+        ((value ushr 16) and 0xFF).toByte(),
+        ((value ushr 24) and 0xFF).toByte(),
+    )
+
+    /**
+     * Hand-assembled CKPY v1 bytes in the exact on-disk order: 48-byte header, then one
+     * record per entry (key framing + candidate framing). Bypasses every production write
+     * path on purpose.
+     */
+    private fun tableBytes(
+        language: String = "zh",
+        entries: List<FixtureEntry>,
+        trailing: ByteArray = ByteArray(0),
+    ): ByteArray {
+        val body = ByteArrayOutputStream()
+        for (entry in entries) {
+            val key = entry.key.toByteArray(Charsets.UTF_8)
+            body.write(u16(key.size))
+            body.write(key)
+            body.write(u16(entry.candidates.size))
+            for ((text, rank) in entry.candidates) {
+                val textBytes = text.toByteArray(Charsets.UTF_8)
+                body.write(u16(textBytes.size))
+                body.write(textBytes)
+                body.write(byteArrayOf(rank.toByte()))
+            }
+        }
+        val bodyBytes = body.toByteArray()
+
+        val header = ByteArrayOutputStream()
+        header.write("CKPY".toByteArray(Charsets.US_ASCII)) // 0: magic
+        header.write(u32(1))                                // 4: version
+        header.write(language.toByteArray(Charsets.UTF_8).copyOf(4)) // 8: language, NUL-padded
+        header.write(u32(entries.size))                     // 12: keyCount
+        header.write(u32(48))                               // 16: dataOffset
+        header.write(ByteArray(28))                         // 20: reserved (zero)
+        return header.toByteArray() + bodyBytes + trailing
+    }
+
+    /** The canonical two-key fixture: `ni` with two candidates, `nihao` with one. */
+    private fun niHaoTable() = tableBytes(
+        entries = listOf(
+            FixtureEntry("ni", listOf("\u4F60" to 0, "\u5C3C" to 1)),      // 你, 尼
+            FixtureEntry("nihao", listOf("\u4F60\u597D" to 0)),             // 你好
+        )
+    )
+
+    // --------------------------------------------------------------------- header pins
+
+    @Test
+    fun headerFieldsPinTheCkpyV1Layout() {
+        val bytes = niHaoTable()
+        val hex = bytes.map { it.toInt() and 0xFF }
+
+        assertWithMessage("CKPY magic must be the ASCII bytes C K P Y")
+            .that(hex.subList(0, 4))
+            .isEqualTo(listOf(0x43, 0x4B, 0x50, 0x59))
+        assertWithMessage("version 1, little-endian")
+            .that(hex.subList(4, 8))
+            .isEqualTo(listOf(0x01, 0x00, 0x00, 0x00))
+        assertWithMessage("4-byte UTF-8 language tag, NUL-padded")
+            .that(hex.subList(8, 12))
+            .isEqualTo(listOf('z'.code, 'h'.code, 0x00, 0x00))
+        assertWithMessage("keyCount at offset 12, little-endian")
+            .that(hex.subList(12, 16))
+            .isEqualTo(listOf(0x02, 0x00, 0x00, 0x00))
+        assertWithMessage("dataOffset at offset 16 points just past the 48-byte header")
+            .that(hex.subList(16, 20))
+            .isEqualTo(listOf(0x30, 0x00, 0x00, 0x00))
+        assertWithMessage("reserved bytes 20..47 must be zero")
+            .that(hex.subList(20, 48))
+            .isEqualTo(List(28) { 0x00 })
+    }
+
+    @Test
+    fun recordFramingPinsLengthPrefixedUtf8AndRankBytes() {
+        val bytes = niHaoTable()
+        val body = bytes.copyOfRange(48, bytes.size)
+
+        // ni: u16 2 | "ni" | u16 2 | u16 3 | 你(BE4BD A0) | 0 | u16 3 | 尼(E5B0BC) | 1
+        // nihao: u16 5 | "nihao" | u16 1 | u16 6 | 你好(E4BDA0E5A5BD) | 0
+        val expected = listOf(
+            0x02, 0x00, 0x6E, 0x69, 0x02, 0x00,
+            0x03, 0x00, 0xE4, 0xBD, 0xA0, 0x00,
+            0x03, 0x00, 0xE5, 0xB0, 0xBC, 0x01,
+            0x05, 0x00, 0x6E, 0x69, 0x68, 0x61, 0x6F, 0x01, 0x00,
+            0x06, 0x00, 0xE4, 0xBD, 0xA0, 0xE5, 0xA5, 0xBD, 0x00,
+        ).map { it.toByte() }
+
+        assertThat(body.toList()).isEqualTo(expected)
+    }
+
+    // --------------------------------------------------------------------------- parsing
+
+    @Test
+    fun aParsedTableExposesItsLanguageAndOrderedEntries() {
+        val table = CkpyPhraseTable.read(niHaoTable())
+
+        assertThat(table.language).isEqualTo("zh")
+        assertThat(table.entries.map { it.key }).containsExactly("ni", "nihao").inOrder()
+        assertThat(table.entries[0].candidates.map { it.text })
+            .containsExactly("\u4F60", "\u5C3C").inOrder()
+        assertThat(table.entries[0].candidates.map { it.rank }).containsExactly(0, 1).inOrder()
+        assertThat(table.entries[1].candidates.single())
+            .isEqualTo(CkpyPhraseTable.Candidate("\u4F60\u597D", 0))
+    }
+
+    @Test
+    fun readFromAFileMatchesReadFromBytes() {
+        val bytes = niHaoTable()
+        val file = Files.createTempFile("ckpy-test", ".bin").toFile()
+        try {
+            file.writeBytes(bytes)
+            assertThat(CkpyPhraseTable.read(file).entries).isEqualTo(CkpyPhraseTable.read(bytes).entries)
+        } finally {
+            file.delete()
+        }
+    }
+
+    @Test
+    fun lookupIsExact() {
+        val table = CkpyPhraseTable.read(niHaoTable())
+
+        assertThat(table.lookup("ni")?.candidates?.first()?.text).isEqualTo("\u4F60")
+        assertThat(table.lookup("nihao")?.candidates?.single()?.text).isEqualTo("\u4F60\u597D")
+        assertWithMessage("a pinyin spelling that is not a key returns null, never a fallback")
+            .that(table.lookup("nihaoma")).isNull()
+    }
+
+    @Test
+    fun withPrefixReturnsTheContiguousRunInKeyOrder() {
+        val table = CkpyPhraseTable.read(
+            tableBytes(
+                entries = listOf(
+                    FixtureEntry("hao", listOf("\u597D" to 0)),
+                    FixtureEntry("ni", listOf("\u4F60" to 0)),
+                    FixtureEntry("nian", listOf("\u5E74" to 0)),
+                    FixtureEntry("niang", listOf("\u5A18" to 0)),
+                    FixtureEntry("nihao", listOf("\u4F60\u597D" to 0)),
+                )
+            )
+        )
+
+        assertThat(table.withPrefix("ni").map { it.key })
+            .containsExactly("ni", "nian", "niang", "nihao").inOrder()
+        assertThat(table.withPrefix("nia").map { it.key })
+            .containsExactly("nian", "niang").inOrder()
+        assertThat(table.withPrefix("n").map { it.key })
+            .containsExactly("ni", "nian", "niang", "nihao").inOrder()
+        assertThat(table.withPrefix("h").map { it.key }).containsExactly("hao")
+        assertThat(table.withPrefix("zzz")).isEmpty()
+        assertWithMessage("an empty prefix must not scan the whole table")
+            .that(table.withPrefix("")).isEmpty()
+    }
+
+    @Test
+    fun lookupsRequireANormalizedQuery() {
+        val table = CkpyPhraseTable.read(niHaoTable())
+        for (bad in listOf("Ni", "ni3", "ni hao", "\u4F60")) {
+            assertWithMessage("lookup(\"$bad\") must be rejected, not fuzzy-matched")
+                .that(runCatching { table.lookup(bad) }.exceptionOrNull())
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+        assertThat(runCatching { table.withPrefix("NI") }.exceptionOrNull())
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    // ------------------------------------------------------------------------ rejections
+
+    private fun rejection(bytes: ByteArray): Throwable? =
+        runCatching { CkpyPhraseTable.read(bytes) }.exceptionOrNull()
+
+    @Test
+    fun badMagicIsRejected() {
+        val bytes = niHaoTable().also { it[0] = 'X'.code.toByte() }
+        assertThat(rejection(bytes)).hasMessageThat().contains("not a CKPY phrase table")
+    }
+
+    @Test
+    fun wrongVersionIsRejected() {
+        val bytes = niHaoTable().also { it[4] = 2 }
+        assertThat(rejection(bytes)).hasMessageThat().contains("unsupported CKPY version 2")
+    }
+
+    @Test
+    fun truncatedTablesAreRejectedWithTheFailingField() {
+        assertWithMessage("a 40-byte file is shorter than the fixed header")
+            .that(rejection(niHaoTable().copyOfRange(0, 40)))
+            .hasMessageThat().contains("too short")
+
+        assertWithMessage("a header whose body is cut off mid-record must say which field")
+            .that(rejection(niHaoTable().copyOfRange(0, 52)))
+            .hasMessageThat().contains("truncated")
+    }
+
+    @Test
+    fun unsortedOrDuplicateKeysAreRejected() {
+        val duplicate = tableBytes(
+            entries = listOf(
+                FixtureEntry("ni", listOf("\u4F60" to 0)),
+                FixtureEntry("ni", listOf("\u5C3C" to 0)),
+            )
+        )
+        assertThat(rejection(duplicate))
+            .hasMessageThat().contains("not strictly ascending")
+
+        val descending = tableBytes(
+            entries = listOf(
+                FixtureEntry("nihao", listOf("\u4F60\u597D" to 0)),
+                FixtureEntry("ni", listOf("\u4F60" to 0)),
+            )
+        )
+        assertThat(rejection(descending))
+            .hasMessageThat().contains("not strictly ascending")
+    }
+
+    @Test
+    fun nonNormalizedKeysAndOutOfOrderRanksAreRejected() {
+        val uppercase = tableBytes(entries = listOf(FixtureEntry("Ni", listOf("\u4F60" to 0))))
+        assertThat(rejection(uppercase)).hasMessageThat().contains("not normalized")
+
+        val badRanks = tableBytes(
+            entries = listOf(FixtureEntry("ni", listOf("\u4F60" to 1, "\u5C3C" to 0)))
+        )
+        assertThat(rejection(badRanks)).hasMessageThat().contains("not rank-ordered")
+    }
+
+    @Test
+    fun trailingBytesAreRejected() {
+        val bytes = tableBytes(
+            entries = listOf(FixtureEntry("ni", listOf("\u4F60" to 0))),
+            trailing = byteArrayOf(0x00, 0x01, 0x02),
+        )
+        assertThat(rejection(bytes)).hasMessageThat().contains("trailing bytes")
+    }
+
+    @Test
+    fun anEmptyTableIsRejected() {
+        assertWithMessage("a pack with zero phrase keys is corrupt, not a valid table")
+            .that(rejection(tableBytes(entries = emptyList())))
+            .hasMessageThat().contains("keyCount 0")
+    }
+}

--- a/src/test/kotlin/tribixbite/cleverkeys/pinyin/PinyinControllerTest.kt
+++ b/src/test/kotlin/tribixbite/cleverkeys/pinyin/PinyinControllerTest.kt
@@ -1,0 +1,314 @@
+package tribixbite.cleverkeys.pinyin
+
+import android.util.Log
+import android.view.KeyEvent
+import android.view.inputmethod.InputConnection
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import tribixbite.cleverkeys.SuggestionBar
+import tribixbite.cleverkeys.langpack.LanguagePackManager
+import tribixbite.cleverkeys.langpack.LanguagePackManifest
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.file.Files
+
+/**
+ * Mock-tier tests for the IME glue: mode activation from the installed pack's
+ * `inputMethod`, the composing-region path, the committed-text fallback when an editor
+ * refuses `setComposingText`, candidate taps, swipe feeding, and password bypass.
+ *
+ * Runs under `runMockTests` (android.jar stubs + MockK), like the other Android-touching
+ * suites. The table file is real CKPY bytes parsed by the real reader.
+ */
+class PinyinControllerTest {
+
+    private lateinit var bar: SuggestionBar
+    private lateinit var ic: InputConnection
+    private lateinit var packManager: LanguagePackManager
+    private lateinit var scratch: File
+    private var language = "zh"
+    private lateinit var phrasesFile: File
+    private lateinit var controller: PinyinController
+
+    /**
+     * Minimal editor mirror: `committedText` is real text, `composingText` is the active
+     * composing region, and `getTextBeforeCursor` answers as the concatenation. Real
+     * `setComposingText`/`commitText`/`deleteSurroundingText`/`finishComposingText`
+     * semantics — the first version of this test stubbed the cursor text to "", which made
+     * the controller correctly treat every run as stale.
+     */
+    private var committedText = ""
+    private var composingText = ""
+
+    private fun editorContent(): String = committedText + composingText
+
+    // --------------------------------------------------------------------- fixtures
+
+    private fun u16(value: Int) = byteArrayOf(
+        (value and 0xFF).toByte(),
+        ((value ushr 8) and 0xFF).toByte(),
+    )
+
+    private fun u32(value: Int) = byteArrayOf(
+        (value and 0xFF).toByte(),
+        ((value ushr 8) and 0xFF).toByte(),
+        ((value ushr 16) and 0xFF).toByte(),
+        ((value ushr 24) and 0xFF).toByte(),
+    )
+
+    /** Hand-assembled CKPY v1 bytes for `key -> [(text, rank)]`. */
+    private fun ckpy(vararg entries: Pair<String, List<Pair<String, Int>>>): ByteArray {
+        val body = ByteArrayOutputStream()
+        for ((key, candidates) in entries.sortedBy { it.first }) {
+            val keyBytes = key.toByteArray(Charsets.UTF_8)
+            body.write(u16(keyBytes.size))
+            body.write(keyBytes)
+            body.write(u16(candidates.size))
+            for ((text, rank) in candidates) {
+                val textBytes = text.toByteArray(Charsets.UTF_8)
+                body.write(u16(textBytes.size))
+                body.write(textBytes)
+                body.write(byteArrayOf(rank.toByte()))
+            }
+        }
+        val header = ByteArrayOutputStream()
+        header.write("CKPY".toByteArray(Charsets.US_ASCII))
+        header.write(u32(1))
+        header.write("zh".toByteArray(Charsets.UTF_8).copyOf(4))
+        header.write(u32(entries.size))
+        header.write(u32(48))
+        header.write(ByteArray(28))
+        return header.toByteArray() + body.toByteArray()
+    }
+
+    private fun writePhrases(vararg entries: Pair<String, List<Pair<String, Int>>>): File {
+        val file = File(scratch, "phrases-${entries.size}.bin")
+        file.writeBytes(ckpy(*entries))
+        return file
+    }
+
+    private fun pinyinPack(code: String = "zh"): LanguagePackManager {
+        val manager = mockk<LanguagePackManager>()
+        every { manager.getInstalledPack(code) } returns LanguagePackManifest(
+            code, "中文（拼音）", inputMethod = LanguagePackManager.INPUT_METHOD_PINYIN
+        )
+        every { manager.getPhrasesPath(code) } returns phrasesFile
+        return manager
+    }
+
+    @Before
+    fun setup() {
+        mockkStatic(Log::class)
+        every { Log.d(any(), any<String>()) } returns 0
+        every { Log.w(any(), any<String>()) } returns 0
+        every { Log.e(any(), any<String>()) } returns 0
+        every { Log.e(any(), any<String>(), any()) } returns 0
+
+        scratch = Files.createTempDirectory("ck-pinyin").toFile()
+        phrasesFile = writePhrases("ni" to listOf("\u4F60" to 0))
+        bar = mockk(relaxed = true)
+        ic = mockk(relaxed = true)
+        committedText = ""
+        composingText = ""
+        every { ic.setComposingText(any(), any()) } answers {
+            composingText = firstArg<CharSequence>().toString()
+            true
+        }
+        every { ic.commitText(any(), any()) } answers {
+            committedText += firstArg<CharSequence>().toString()
+            composingText = ""
+            true
+        }
+        every { ic.finishComposingText() } answers {
+            committedText += composingText
+            composingText = ""
+            true
+        }
+        every { ic.deleteSurroundingText(any(), any()) } answers {
+            committedText = committedText.dropLast(firstArg<Int>().coerceAtMost(committedText.length))
+            true
+        }
+        every { ic.getTextBeforeCursor(any(), any()) } answers {
+            editorContent().takeLast(firstArg<Int>())
+        }
+        packManager = pinyinPack()
+
+        controller = PinyinController(
+            languageProvider = { language },
+            inputConnectionProvider = { ic },
+            suggestionBarProvider = { bar },
+            packManagerProvider = { packManager },
+            scope = CoroutineScope(Dispatchers.Unconfined),
+            ioDispatcher = Dispatchers.Unconfined,
+        )
+    }
+
+    @After
+    fun teardown() {
+        unmockkAll()
+        scratch.deleteRecursively()
+    }
+
+    // ------------------------------------------------------------------- activation
+
+    @Test
+    fun aNonPinyinLanguageLeavesTheModeInactive() {
+        language = "en"
+        val enManager = mockk<LanguagePackManager>()
+        every { enManager.getInstalledPack("en") } returns null
+        controller = PinyinController(
+            languageProvider = { language },
+            inputConnectionProvider = { ic },
+            suggestionBarProvider = { bar },
+            packManagerProvider = { enManager },
+            scope = CoroutineScope(Dispatchers.Unconfined),
+            ioDispatcher = Dispatchers.Unconfined,
+        )
+
+        controller.onStartInputView(isPasswordField = false)
+
+        assertThat(controller.isActive()).isFalse()
+        assertThat(controller.handleTypedText("n")).isFalse()
+    }
+
+    @Test
+    fun passwordFieldsNeverActivateEvenForAPinyinPack() {
+        controller.onStartInputView(isPasswordField = true)
+
+        assertThat(controller.isActive()).isFalse()
+        assertThat(controller.handleTypedText("n")).isFalse()
+    }
+
+    @Test
+    fun aPinyinPackWithoutAPhraseTableFallsBackToLatin() {
+        val manager = pinyinPack()
+        every { manager.getPhrasesPath("zh") } returns null
+        controller = PinyinController(
+            languageProvider = { language },
+            inputConnectionProvider = { ic },
+            suggestionBarProvider = { bar },
+            packManagerProvider = { manager },
+            scope = CoroutineScope(Dispatchers.Unconfined),
+            ioDispatcher = Dispatchers.Unconfined,
+        )
+
+        controller.onStartInputView(isPasswordField = false)
+
+        assertWithMessage("a declared mode with an unusable table must degrade, not break")
+            .that(controller.isActive()).isFalse()
+        assertThat(controller.handleTypedText("n")).isFalse()
+    }
+
+    // -------------------------------------------------------------------- composing
+
+    @Test
+    fun typingPublishesThePreeditAndTheCandidatesAndSpaceCommitsTheTopOne() {
+        controller.onStartInputView(isPasswordField = false)
+        assertThat(controller.isActive()).isTrue()
+
+        assertThat(controller.handleTypedText("n")).isTrue()
+        verify { ic.setComposingText("n", 1) }
+        assertThat(controller.handleTypedText("i")).isTrue()
+        verify { ic.setComposingText("ni", 1) }
+        verify { bar.setSuggestionsWithScores(listOf("\u4F60"), any(), any()) }
+
+        assertThat(controller.handleTypedText(" ")).isTrue()
+        verify { ic.commitText("\u4F60", 1) }
+        verify { bar.clearSuggestions() }
+    }
+
+    @Test
+    fun aCandidateTapCommitsAndNonCandidateWordsAreNotStolen() {
+        controller.onStartInputView(isPasswordField = false)
+        controller.handleTypedText("n")
+        controller.handleTypedText("i")
+
+        assertThat(controller.onCandidateSelected("hello")).isFalse()
+        assertThat(controller.onCandidateSelected("\u4F60")).isTrue()
+        verify { ic.commitText("\u4F60", 1) }
+    }
+
+    @Test
+    fun backspaceShortensTheRunThenHandsBackspaceToTheEditor() {
+        controller.onStartInputView(isPasswordField = false)
+        controller.handleTypedText("n")
+        controller.handleTypedText("i")
+
+        assertThat(controller.handleBackspace()).isTrue()
+        verify { ic.setComposingText("n", 1) }
+        assertThat(controller.handleBackspace()).isTrue()
+        verify { ic.setComposingText("", 1) }
+        assertWithMessage("an empty composing run must not eat the backspace")
+            .that(controller.handleBackspace()).isFalse()
+    }
+
+    @Test
+    fun escapeCancelsTheComposingRun() {
+        controller.onStartInputView(isPasswordField = false)
+        controller.handleTypedText("n")
+
+        assertThat(controller.handleKeyevent(KeyEvent.KEYCODE_ESCAPE)).isTrue()
+        verify { ic.setComposingText("", 1) }
+    }
+
+    @Test
+    fun enterCommitsTheTopCandidateWithoutConsumingTheKey() {
+        controller.onStartInputView(isPasswordField = false)
+        controller.handleTypedText("n")
+        controller.handleTypedText("i")
+
+        assertWithMessage("false lets KeyEventHandler still send the editor action")
+            .that(controller.handleKeyevent(KeyEvent.KEYCODE_ENTER)).isFalse()
+        verify { ic.commitText("\u4F60", 1) }
+    }
+
+    // -------------------------------------------------------- swipe + fallback paths
+
+    @Test
+    fun aSwipeFeedsThePinyinSurfaceAndNeverAutoCommits() {
+        phrasesFile = writePhrases("nihao" to listOf("\u4F60\u597D" to 0))
+        packManager = pinyinPack()
+        controller = PinyinController(
+            languageProvider = { language },
+            inputConnectionProvider = { ic },
+            suggestionBarProvider = { bar },
+            packManagerProvider = { packManager },
+            scope = CoroutineScope(Dispatchers.Unconfined),
+            ioDispatcher = Dispatchers.Unconfined,
+        )
+        controller.onStartInputView(isPasswordField = false)
+
+        assertThat(controller.onSwipeDecoded(listOf("nihao"), emptyList())).isTrue()
+
+        verify { ic.setComposingText("nihao", 1) }
+        verify(exactly = 0) { ic.commitText(any(), any()) }
+        verify { bar.setSuggestionsWithScores(listOf("\u4F60\u597D"), any(), any()) }
+    }
+
+    @Test
+    fun anEditorThatRefusesComposingGetsTheCommittedTextFallback() {
+        every { ic.setComposingText(any(), any()) } returns false
+        controller.onStartInputView(isPasswordField = false)
+
+        assertThat(controller.handleTypedText("n")).isTrue()
+        verify { ic.commitText("n", 1) }
+        assertThat(controller.handleTypedText("i")).isTrue()
+        verify { ic.commitText("i", 1) }
+        assertThat(editorContent()).isEqualTo("ni")
+
+        assertThat(controller.handleTypedText(" ")).isTrue()
+        verify { ic.deleteSurroundingText(2, 0) }
+        verify { ic.commitText("\u4F60", 1) }
+        assertThat(editorContent()).isEqualTo("\u4F60")
+    }
+}

--- a/src/test/kotlin/tribixbite/cleverkeys/pinyin/PinyinSessionTest.kt
+++ b/src/test/kotlin/tribixbite/cleverkeys/pinyin/PinyinSessionTest.kt
@@ -1,0 +1,223 @@
+package tribixbite.cleverkeys.pinyin
+
+import com.google.common.truth.Truth.assertThat
+import com.google.common.truth.Truth.assertWithMessage
+import org.junit.Test
+
+/**
+ * Pins the pinyin composing state machine: normalization, deterministic candidate
+ * assembly (exact → completions → greedy segmentation), and the buffer edit rules.
+ * Pure JVM — the pack/table bytes are the in-memory [CkpyPhraseTable.Table] the reader
+ * produces (whose own byte layout is pinned by [CkpyPhraseTableTest]).
+ */
+class PinyinSessionTest {
+
+    // --------------------------------------------------------------------- fixtures
+
+    /** One key with `text to rank` candidates, assembled in-memory (no file needed). */
+    private fun entry(key: String, vararg candidates: Pair<String, Int>): CkpyPhraseTable.Entry =
+        CkpyPhraseTable.Entry(key, candidates.map { CkpyPhraseTable.Candidate(it.first, it.second) })
+
+    /** A table with keys sorted ascending, as the CKPY reader guarantees. */
+    private fun table(vararg entries: CkpyPhraseTable.Entry): CkpyPhraseTable.Table =
+        CkpyPhraseTable.Table("zh", entries.sortedBy { it.key })
+
+    private fun session(vararg entries: CkpyPhraseTable.Entry): PinyinSession =
+        PinyinSession(table(*entries))
+
+    // ------------------------------------------------------------------ normalization
+
+    @Test
+    fun appendLetterNormalizesCaseApostrophesAndUmlaut() {
+        val s = session(entry("nv", "\u5973" to 0), entry("xi'an", "\u897F\u5B89" to 0))
+
+        assertWithMessage("uppercase keys arrive with shift on; the buffer is lowercase")
+            .that(s.appendLetter('N')).isTrue()
+        assertThat(s.composingText).isEqualTo("n")
+        assertThat(s.appendLetter('V')).isTrue()
+        assertWithMessage("v spells ü (女 = nv)")
+            .that(s.composingText).isEqualTo("nv")
+        assertThat(s.appendLetter('\u00fc')).isTrue() // ü
+        assertThat(s.composingText).isEqualTo("nvv")
+
+        s.clear()
+        assertWithMessage("curly apostrophes normalize to the ASCII key separator")
+            .that(s.appendLetter('\u2019')).isTrue()
+        assertThat(s.composingText).isEqualTo("'")
+
+        assertWithMessage("digits are not pinyin input — the caller commits them normally")
+            .that(s.appendLetter('3')).isFalse()
+        assertThat(s.appendLetter(' ')).isFalse()
+        assertThat(s.appendLetter('.')).isFalse()
+    }
+
+    @Test
+    fun appendSurfaceKeepsOnlyPinyinAndReturnsWhatWasAppended() {
+        val s = session(entry("nihao", "\u4F60\u597D" to 0))
+
+        val appended = s.appendSurface("Ni3hao!")
+
+        assertThat(appended).isEqualTo("nihao")
+        assertThat(s.composingText).isEqualTo("nihao")
+    }
+
+    @Test
+    fun bufferIsCappedAtTheConfiguredLength() {
+        val s = session(entry("a", "\u554A" to 0))
+        repeat(PinyinSession.MAX_BUFFER_LENGTH) {
+            assertWithMessage("append $it must fit").that(s.appendLetter('a')).isTrue()
+        }
+        assertThat(s.isFull).isTrue()
+        assertThat(s.appendLetter('a')).isFalse()
+        assertThat(s.appendSurface("aaa")).isEmpty()
+    }
+
+    // -------------------------------------------------------------- candidate assembly
+
+    @Test
+    fun candidatesPutTheExactKeyFirstThenCompletionKeysInTableOrder() {
+        val s = session(
+            entry("ni", "\u4F60" to 0, "\u5C3C" to 1),
+            entry("nian", "\u5E74" to 0),
+            entry("niang", "\u5A18" to 0),
+            entry("nihao", "\u4F60\u597D" to 0),
+        )
+        s.appendSurface("ni")
+
+        assertThat(s.candidates().map { it.text }).containsExactly(
+            "\u4F60", "\u5C3C", "\u5E74", "\u5A18", "\u4F60\u597D"
+        ).inOrder()
+    }
+
+    @Test
+    fun aPartialSyllableShowsCompletionCandidates() {
+        val s = session(
+            entry("nihao", "\u4F60\u597D" to 0),
+            entry("ni", "\u4F60" to 0),
+        )
+        s.appendSurface("nih")
+
+        assertThat(s.candidates().map { it.text }).containsExactly("\u4F60\u597D")
+    }
+
+    @Test
+    fun duplicateCandidateTextIsOfferedOnce() {
+        val s = session(
+            entry("ni", "\u4F60" to 0),
+            entry("nian", "\u4F60" to 0), // same 你 under a completion key
+        )
+        s.appendSurface("ni")
+
+        assertThat(s.candidates().map { it.text }).containsExactly("\u4F60")
+    }
+
+    @Test
+    fun anExactMultiSyllableKeyWinsOverSegmentation() {
+        val s = session(
+            entry("xian", "\u5148" to 0),
+            entry("xi", "\u897F" to 0),
+            entry("an", "\u5B89" to 0),
+        )
+        s.appendSurface("xian")
+
+        assertThat(s.topCandidate()).isEqualTo("\u5148")
+    }
+
+    @Test
+    fun candidatesAreBoundedAndScoredDescending() {
+        val many = (0 until 20).map { "\u5B57$it" to it }
+        val s = session(entry("a", *many.toTypedArray()))
+        s.appendSurface("a")
+
+        val candidates = s.candidates()
+        assertThat(candidates).hasSize(PinyinSession.MAX_CANDIDATES)
+        for (i in 1 until candidates.size) {
+            assertWithMessage("rank order must survive the score projection")
+                .that(candidates[i].score).isAtMost(candidates[i - 1].score)
+        }
+    }
+
+    // ------------------------------------------------------------------- segmentation
+
+    @Test
+    fun segmentationJoinsKnownSyllablesWhenNoSingleKeyMatches() {
+        val s = session(
+            entry("wo", "\u6211" to 0),
+            entry("ai", "\u7231" to 0),
+            entry("ni", "\u4F60" to 0),
+        )
+        s.appendSurface("woaini")
+
+        assertWithMessage("五 我 + 爱 + 你 joins to 我爱你")
+            .that(s.topCandidate()).isEqualTo("\u6211\u7231\u4F60")
+    }
+
+    @Test
+    fun segmentationUsesGreedyLongestMatch() {
+        val s = session(
+            entry("fang", "\u623F" to 0),
+            entry("fan", "\u996D" to 0),
+            entry("an", "\u5B89" to 0),
+        )
+        s.appendSurface("fangan")
+
+        assertWithMessage("longest match at position 0 is 房 (fang), not 饭 (fan)")
+            .that(s.topCandidate()).isEqualTo("\u623F\u5B89")
+    }
+
+    @Test
+    fun segmentationOffersSecondCandidateVariantsForTrailingSegments() {
+        val s = session(
+            entry("wo", "\u6211" to 0, "\u63E1" to 1),
+            entry("ai", "\u7231" to 0),
+            entry("ni", "\u4F60" to 0, "\u5C3C" to 1),
+        )
+        s.appendSurface("woaini")
+
+        val texts = s.candidates().map { it.text }
+        assertThat(texts).contains("\u6211\u7231\u4F60")     // base join
+        assertThat(texts).contains("\u6211\u7231\u5C3C")     // trailing segment's runner-up
+        assertThat(texts).contains("\u63E1\u7231\u4F60")     // leading segment's runner-up
+    }
+
+    @Test
+    fun unsegmentableInputOffersNothing() {
+        val s = session(entry("ni", "\u4F60" to 0))
+        s.appendSurface("niqwerty")
+
+        assertThat(s.candidates()).isEmpty()
+        assertThat(s.composingText).isEqualTo("niqwerty")
+    }
+
+    // ---------------------------------------------------------------------- editing
+
+    @Test
+    fun backspaceShortensUntilEmptyThenRefuses() {
+        val s = session(entry("ni", "\u4F60" to 0))
+        s.appendSurface("ni")
+
+        assertThat(s.backspace()).isTrue()
+        assertThat(s.composingText).isEqualTo("n")
+        assertThat(s.backspace()).isTrue()
+        assertThat(s.isEmpty).isTrue()
+        assertWithMessage("an empty buffer hands backspace back to the normal path")
+            .that(s.backspace()).isFalse()
+    }
+
+    @Test
+    fun clearDropsTheWholeRun() {
+        val s = session(entry("ni", "\u4F60" to 0))
+        s.appendSurface("ni")
+        s.clear()
+
+        assertThat(s.isEmpty).isTrue()
+        assertThat(s.candidates()).isEmpty()
+    }
+
+    @Test
+    fun emptyBufferNeverProducesCandidates() {
+        val s = session(entry("ni", "\u4F60" to 0))
+        assertThat(s.candidates()).isEmpty()
+        assertThat(s.topCandidate()).isNull()
+    }
+}


### PR DESCRIPTION
Refs #177. Implements the pinyin composing IME at the code level — pack contract + container format, tap-first engine, and the swipe feed. Device validation and pack data remain (spelled out at the bottom).

## What's in the PR

**Phase 0 — pack schema + container format**
- `manifest.json` optional `inputMethod`: absent / `"wordfreq"` = legacy (existing packs byte-identical); `"pinyin"` declares a composing pack and requires `phrases.bin`. Unknown values and orphan tables are refused at import.
- `phrases.bin` V1 `CKPY`: 1:N pinyin key → ranked 汉字; 48-byte LE header + strictly ascending key records + length-prefixed candidates + rank bytes. Pure-JVM reader (`CkpyPhraseTable`) with `lookup`/`withPrefix` and full untrusted-input bounding; Python writer + `build_langpack.py --input-method/--phrases`.

**Phase 1 — tap-first engine**
- `PinyinSession` (pure JVM): buffer + deterministic candidate assembly — exact key, then completion keys, then greedy longest-match segmentation (`woaini` → 我+爱+你) with bounded runner-up variants. Normalization: case, `ü`→`v`, curly apostrophes; 48-char cap.
- `PinyinController`: per-field activation from the installed pack's `inputMethod` + a readable `phrases.bin`; async table load (Latin fallback until ready / on failure); composing region via `setComposingText`; **per-field committed-text fallback** when an editor refuses it (spec Q1 resolved by implementing both — device validation still decides the default); password/PIN never activates; no learning, no English context.
- Wiring: `KeyEventHandler.IReceiver` hooks (text/backspace/keyevent) consulted before `sendText` and the DEL chain; `KeyEventReceiverBridge` gates on modal panes; suggestion taps commit through `SuggestionBridge` → session; `SuggestionOrigin.PINYIN` provenance label + marker; `LanguagePackManager.getInstalledPack(code)` for the mode check.

**Phase 2 — swipe**
- `SuggestionHandler` gains a `PinyinComposingHook` seam checked at the TOP of `handleSwipePredictionResults` (before the password/empty guards): a pinyin decode buffers the spelling, refreshes candidates, and **never auto-commits** or renders an English slate.

**Docs** — `docs/specs/pinyin-ime.md` updated to as-built with test pins, Q1 resolution, and an explicit deferrals table.

## Verification (run locally 2026-09-11, JDK 17 + Kotlin 2.0.0, Gradle via `scripts/gradle-guard.sh`)
- `compileDebugKotlin` green.
- `runPureTests`: `PinyinSessionTest` 15/15, `CkpyPhraseTableTest` 14/14; full pure suite **2,400 green** except a pre-existing timing microbenchmark (`GeoBenchmarkTest`, environment-sensitive).
- `runMockTests`: `PinyinControllerTest` 10/10, `LanguagePackImportTest` 35/35, `SuggestionPinyinHookTest` 4/4, `KeyEventReceiverBridgeDelegationTest` 2/2, `SuggestionTapPartialReplaceTest` 5/5, `SuggestionTrailingSpaceRepairTest` 11/11, `SuggestionTapAddAndIWordTest` 12/12.
- Python writer → Kotlin reader cross-check on a generated table (`lü`→`lv`, `ni3`→`ni`, `xi'an`/`xian` distinct).

## Not in this PR (deferred; rationale in the spec)
| Item | Reason |
|---|---|
| On-device validation of composing region + geometric swipe quality | needs the test phones |
| Distributable `zh-Hans` / `zh-Hant` packs | data source/licence (open question Q4) |
| Context-aware ranking, user-selection learning | needs Hanzi context + a privacy/storage design |
| Space-behavior setting | fixed to the Chinese commit-without-space convention for now |
| CTC `zh` row | no pinyin swipe corpus to justify the PROVISIONAL tier |
| Lattice segmentation | greedy longest-match ships first |

## Open question for review
Q1 (composing region vs commit-and-replace): I implemented the composing region with the replace fallback behind the same session, both tested. Recommend validating on device and keeping the composing default; flipping it is a one-line change in `PinyinController`.
